### PR TITLE
Full prompt response transparency

### DIFF
--- a/proxy-router/internal/aiengine/history.go
+++ b/proxy-router/internal/aiengine/history.go
@@ -45,9 +45,11 @@ func (h *History) Prompt(ctx context.Context, prompt *openai.ChatCompletionReque
 		adjustedPrompt = history.AppendChatHistory(prompt)
 	}
 
-	err = h.engine.Prompt(ctx, adjustedPrompt, func(ctx context.Context, completion gcs.Chunk) error {
-		completions = append(completions, completion)
-		return cb(ctx, completion)
+	err = h.engine.Prompt(ctx, adjustedPrompt, func(ctx context.Context, completion gcs.Chunk, errorBody *gcs.AiEngineErrorResponse) error {
+		if errorBody != nil {
+			completions = append(completions, completion)
+		}
+		return cb(ctx, completion, errorBody)
 	})
 	if err != nil {
 		return err

--- a/proxy-router/internal/aiengine/hyperbolic_sd.go
+++ b/proxy-router/internal/aiengine/hyperbolic_sd.go
@@ -92,6 +92,19 @@ func (s *HyperbolicSD) Prompt(ctx context.Context, prompt *openai.ChatCompletion
 		return err
 	}
 
+	if res.StatusCode != http.StatusOK {
+		var aiEngineErrorResponse interface{}
+		if err := json.NewDecoder(res.Body).Decode(&aiEngineErrorResponse); err != nil {
+			return fmt.Errorf("failed to decode response: %v", err)
+		}
+
+		err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(aiEngineErrorResponse))
+		if err != nil {
+			return fmt.Errorf("callback failed: %v", err)
+		}
+		return nil
+	}
+
 	result := HyperbolicImageGenerationResult{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
@@ -105,7 +118,7 @@ func (s *HyperbolicSD) Prompt(ctx context.Context, prompt *openai.ChatCompletion
 		ImageRawContent: dataPrefix + result.Images[0].Image,
 	})
 
-	return cb(ctx, chunk)
+	return cb(ctx, chunk, nil)
 }
 
 func (s *HyperbolicSD) ApiType() string {

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -27,6 +27,9 @@ type OpenAI struct {
 }
 
 func NewOpenAIEngine(modelName, baseURL, apiKey string, log lib.ILogger) *OpenAI {
+	if baseURL != "" {
+		baseURL = strings.TrimSuffix(baseURL, "/")
+	}
 	return &OpenAI{
 		baseURL:   baseURL,
 		modelName: modelName,
@@ -65,15 +68,8 @@ func (a *OpenAI) Prompt(ctx context.Context, compl *openai.ChatCompletionRequest
 	a.log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
-		var errorBody interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&errorBody); err != nil {
-			return fmt.Errorf("failed to decode response: %v", err)
-		}
-		json, err := json.MarshalIndent(errorBody, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to decode error response: %v", err)
-		}
-		return fmt.Errorf("AI Model responded with error: %s", string(json))
+		a.log.Warnf("AI Model responded with error: %s", resp.StatusCode)
+		return a.readError(ctx, resp.Body, cb)
 	}
 
 	if isContentTypeStream(resp.Header) {
@@ -95,11 +91,24 @@ func (a *OpenAI) readResponse(ctx context.Context, body io.Reader, cb gcs.Comple
 	}
 
 	chunk := gcs.NewChunkText(&compl)
-	err := cb(ctx, chunk)
+	err := cb(ctx, chunk, nil)
 	if err != nil {
 		return fmt.Errorf("callback failed: %v", err)
 	}
 
+	return nil
+}
+
+func (a *OpenAI) readError(ctx context.Context, body io.Reader, cb gcs.CompletionCallback) error {
+	var aiEngineErrorResponse interface{}
+	if err := json.NewDecoder(body).Decode(&aiEngineErrorResponse); err != nil {
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(aiEngineErrorResponse))
+	if err != nil {
+		return fmt.Errorf("callback failed: %v", err)
+	}
 	return nil
 }
 
@@ -120,7 +129,7 @@ func (a *OpenAI) readStream(ctx context.Context, body io.Reader, cb gcs.Completi
 			}
 			// Call the callback function with the unmarshalled completion
 			chunk := gcs.NewChunkStreaming(&compl)
-			err := cb(ctx, chunk)
+			err := cb(ctx, chunk, nil)
 			if err != nil {
 				return fmt.Errorf("callback failed: %v", err)
 			}

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -89,11 +89,6 @@ func (a *OpenAI) readResponse(ctx context.Context, body io.Reader, cb gcs.Comple
 		return fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	text := make([]string, len(compl.Choices))
-	for i, choice := range compl.Choices {
-		text[i] = choice.Message.Content
-	}
-
 	chunk := gcs.NewChunkText(&compl)
 	err := cb(ctx, chunk)
 	if err != nil {

--- a/proxy-router/internal/aiengine/prodia_sd.go
+++ b/proxy-router/internal/aiengine/prodia_sd.go
@@ -101,7 +101,7 @@ func (s *ProdiaSD) Prompt(ctx context.Context, prompt *openai.ChatCompletionRequ
 		Status:   job.Status,
 	})
 
-	return cb(ctx, chunk)
+	return cb(ctx, chunk, nil)
 }
 
 func (s *ProdiaSD) ApiType() string {

--- a/proxy-router/internal/aiengine/prodia_sdxl.go
+++ b/proxy-router/internal/aiengine/prodia_sdxl.go
@@ -101,7 +101,7 @@ func (s *ProdiaSDXL) Prompt(ctx context.Context, prompt *openai.ChatCompletionRe
 		Status:   job.Status,
 	})
 
-	return cb(ctx, chunk)
+	return cb(ctx, chunk, nil)
 }
 
 func (s *ProdiaSDXL) ApiType() string {

--- a/proxy-router/internal/blockchainapi/mappers.go
+++ b/proxy-router/internal/blockchainapi/mappers.go
@@ -100,8 +100,8 @@ func mapProvider(addr common.Address, provider pr.IProviderStorageProvider) *str
 }
 
 func mapOrder(order string) registries.Order {
-	if order == "desc" {
-		return registries.OrderDESC
+	if order == "ASC" {
+		return registries.OrderASC
 	}
-	return registries.OrderASC
+	return registries.OrderDESC
 }

--- a/proxy-router/internal/chatstorage/genericchatstorage/completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/completion.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
-type CompletionCallback func(ctx context.Context, completion Chunk) error
+type CompletionCallback func(ctx context.Context, completion Chunk, aiEngineErrorResponse *AiEngineErrorResponse) error
 
 type ChunkType string
 
@@ -213,3 +213,13 @@ var _ Chunk = &ChunkControl{}
 var _ Chunk = &ChunkStreaming{}
 var _ Chunk = &ChunkVideo{}
 var _ Chunk = &ChunkImageRawContent{}
+
+type AiEngineErrorResponse struct {
+	ProviderModelError interface{} `json:"providerModelError"`
+}
+
+func NewAiEngineErrorResponse(ProviderModelError interface{}) *AiEngineErrorResponse {
+	return &AiEngineErrorResponse{
+		ProviderModelError: ProviderModelError,
+	}
+}

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -210,7 +210,12 @@ func (c *ProxyController) Prompt(ctx *gin.Context) {
 			return err
 		}
 
-		_, err = ctx.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", marshalledResponse)))
+		if body.Stream {
+			_, err = ctx.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", marshalledResponse)))
+		} else {
+			_, err = ctx.Writer.Write(marshalledResponse)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -14,7 +14,7 @@ import (
 	constants "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
-	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
+	gsc "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/interfaces"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
@@ -34,7 +34,7 @@ type AIEngine interface {
 type ProxyController struct {
 	service            *ProxyServiceSender
 	aiEngine           AIEngine
-	chatStorage        genericchatstorage.ChatStorageInterface
+	chatStorage        gsc.ChatStorageInterface
 	storeChatContext   bool
 	forwardChatContext bool
 	log                lib.ILogger
@@ -43,7 +43,7 @@ type ProxyController struct {
 	dockerManager      *DockerManager
 }
 
-func NewProxyController(service *ProxyServiceSender, aiEngine AIEngine, chatStorage genericchatstorage.ChatStorageInterface, storeChatContext, forwardChatContext bool, authConfig system.HTTPAuthConfig, ipfsManager *IpfsManager, log lib.ILogger) *ProxyController {
+func NewProxyController(service *ProxyServiceSender, aiEngine AIEngine, chatStorage gsc.ChatStorageInterface, storeChatContext, forwardChatContext bool, authConfig system.HTTPAuthConfig, ipfsManager *IpfsManager, log lib.ILogger) *ProxyController {
 	dockerManager := NewDockerManager(log)
 
 	c := &ProxyController{
@@ -204,7 +204,13 @@ func (c *ProxyController) Prompt(ctx *gin.Context) {
 
 	ctx.Writer.Header().Set(constants.HEADER_CONTENT_TYPE, contentType)
 
-	err = adapter.Prompt(ctx, &body, func(cbctx context.Context, completion genericchatstorage.Chunk) error {
+	err = adapter.Prompt(ctx, &body, func(cbctx context.Context, completion gsc.Chunk, aiResponseError *gsc.AiEngineErrorResponse) error {
+		if aiResponseError != nil {
+			ctx.Writer.Header().Set(constants.HEADER_CONTENT_TYPE, constants.CONTENT_TYPE_JSON)
+			ctx.JSON(http.StatusBadRequest, aiResponseError)
+			return nil
+		}
+
 		marshalledResponse, err := json.Marshal(completion.Data())
 		if err != nil {
 			return err

--- a/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc.go
@@ -243,7 +243,7 @@ func (m *MORRPCMessage) ResponseError(message string, privateKeyHex lib.HexStrin
 	if err != nil {
 		return &RpcResponse{}, err
 	}
-	params2.Data.Signature = &signature
+	params2.Data.Signature = signature
 
 	return &RpcResponse{
 		ID:    requestId,

--- a/proxy-router/internal/proxyapi/morrpcmessage/request.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/request.go
@@ -90,8 +90,8 @@ type RpcError struct {
 }
 
 type RPCErrorData struct {
-	Timestamp uint64         `json:"timestamp" validate:"required,number"`
-	Signature *lib.HexString `json:"signature" validate:"required,hexadecimal"`
+	Timestamp uint64        `json:"timestamp" validate:"required,number"`
+	Signature lib.HexString `json:"signature" validate:"required,hexadecimal"`
 }
 
 type RPCMessage struct {

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -521,7 +521,7 @@ func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.
 			return nil, err
 		}
 
-		err = cb(ctx, gcs.NewChunkControl("provider failed, failover enabled"))
+		err = cb(ctx, gcs.NewChunkControl("provider failed, failover enabled"), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -542,7 +542,7 @@ func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.
 		}
 
 		msg := fmt.Sprintf("new session opened: %s", newSessionID.Hex())
-		err = cb(ctx, gcs.NewChunkControl(msg))
+		err = cb(ctx, gcs.NewChunkControl(msg), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -663,7 +663,26 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 		}
 
 		if msg.Error != nil {
-			return nil, ttftMs, totalTokens, lib.WrapError(ErrResponseErr, fmt.Errorf("error: %v, data: %v", msg.Error.Message, msg.Error.Data))
+			sig := msg.Error.Data.Signature
+			msg.Error.Data.Signature = []byte{}
+
+			if !p.validateMsgSignature(msg.Error, sig, providerPublicKey) {
+				return nil, ttftMs, totalTokens, ErrInvalidSig
+			}
+
+			errorMessage, err := lib.DecryptString(msg.Error.Message, prKey.Hex())
+			if err != nil {
+				return nil, ttftMs, totalTokens, lib.WrapError(ErrDecrFailed, err)
+			}
+
+			var aiEngineErrorResponse gcs.AiEngineErrorResponse
+			err = json.Unmarshal([]byte(errorMessage), &aiEngineErrorResponse)
+			if err != nil {
+				return nil, ttftMs, totalTokens, lib.WrapError(ErrInvalidResponse, err)
+			}
+
+			cb(ctx, nil, &aiEngineErrorResponse)
+			return nil, ttftMs, totalTokens, nil
 		}
 
 		if msg.Result == nil {
@@ -744,7 +763,7 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 		if ctx.Err() != nil {
 			return nil, ttftMs, totalTokens, ctx.Err()
 		}
-		err = cb(ctx, chunk)
+		err = cb(ctx, chunk, nil)
 		if err != nil {
 			return nil, ttftMs, totalTokens, lib.WrapError(ErrResponseErr, err)
 		}


### PR DESCRIPTION
In the past, the response from back-end provider was masked
Now, with agents and tools requiring full feedback, we needed to ensure that messaging from the LLM provider was passed cleanly back through the proxy router on the provider and the client nodes.