### PR TITLE
feat: support streaming for gpt-4o models

### DIFF
--- a/proxy-router/internal/chatstorage/file_chat_storage.go
+++ b/proxy-router/internal/chatstorage/file_chat_storage.go
@@ -63,7 +63,9 @@ func (cs *ChatStorage) StorePromptResponseToFile(identifier string, isLocal bool
 	if len(responses) > 0 {
 		isImageContent = responses[0].Type() == gcs.ChunkTypeImage
 		isVideoRawContent = responses[0].Type() == gcs.ChunkTypeVideo
-		isAudioContent = responses[0].Type() == gcs.ChunkTypeAudioTranscriptionText || responses[0].Type() == gcs.ChunkTypeAudioTranscriptionJson
+		isAudioContent = responses[0].Type() == gcs.ChunkTypeAudioTranscriptionText || 
+			responses[0].Type() == gcs.ChunkTypeAudioTranscriptionJson ||
+			responses[0].Type() == gcs.ChunkTypeAudioTranscriptionDelta
 	}
 
 	var newEntry gcs.ChatMessage

--- a/proxy-router/internal/chatstorage/genericchatstorage/interface.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/interface.go
@@ -134,4 +134,5 @@ type AudioTranscriptionRequest struct {
 	Format                 openai.AudioResponseFormat
 	TimestampGranularities []openai.TranscriptionTimestampGranularity // Only for transcription.
 	TimestampGranularity   openai.TranscriptionTimestampGranularity
+	Stream                 bool // Whether to stream the transcription results
 }


### PR DESCRIPTION
Models-config example for streaming models:
```
 {
      "modelId": "0xe086adc275c99e32bb10b0aff5e8bfc391aad18cbb184727a75b2569149425c6",
      "modelName": "gpt-4o-transcribe",
      "apiType": "openai",
      "apiUrl": "https://api.openai.com/v1/audio/transcriptions",
      "apiKey": ""
    }
```
 ```
{
      "modelId": "0xe086adc275c99e32bb10b0aff5e8bfc391aad18cbb184727a75b2569149425c6",
      "modelName": "gpt-4o-mini-transcribe",
      "apiType": "openai",
      "apiUrl": "https://api.openai.com/v1/audio/transcriptions",
      "apiKey": ""
    }
```

Request example:
```
curl --location 'http://localhost:8084/v1/audio/transcriptions' \
--header 'model_id: 0xe086adc275c99e32bb10b0aff5e8bfc391aad18cbb184727a75b2569149425c6' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--form 'file=@"/Users/sandrk/Downloads/harvard.wav"' \
--form 'response_format="json"' \
--form 'stream="true"'
```
Note: the only supported (by OpenAI) `response_format` is `json`