### PR TITLE
Feat/timeouts configuration

### DIFF
--- a/proxy-router/.env.example
+++ b/proxy-router/.env.example
@@ -49,3 +49,17 @@ LOG_LEVEL_APP=warn
 LOG_LEVEL_TCP=warn
 LOG_LEVEL_ETH_RPC=warn
 LOG_LEVEL_STORAGE=warn
+
+# LLM Timeout: max duration for PNode to LLM requests (streaming and non-streaming)
+# Default: 4m (240 seconds). Supports Go duration strings: 30s, 5m, 1h, etc.
+LLM_TIMEOUT=4m
+
+# CNode to PNode timeout: per-attempt timeout waiting for PNode first response
+# Default: 90s. Supports Go duration strings: 30s, 5m, etc.
+CNODE_PNODE_TIMEOUT=90s
+#
+# Max retries for chat/embeddings (total budget = timeout * retries, default: 90s * 3 = 4.5 min)
+CNODE_PNODE_MAX_RETRIES=3
+#
+# Max retries for audio transcription/speech (default: 90s * 20 = 30 min)
+CNODE_PNODE_AUDIO_MAX_RETRIES=20

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -283,7 +283,7 @@ func start() error {
 	sessionRouter := registries.NewSessionRouter(*cfg.Marketplace.DiamondContractAddress, ethClient, multicallBackend, rpcLog)
 	marketplace := registries.NewMarketplace(*cfg.Marketplace.DiamondContractAddress, ethClient, multicallBackend, rpcLog)
 	sessionRepo := sessionrepo.NewSessionRepositoryCached(sessionStorage, sessionRouter, marketplace, appLog)
-	proxyRouterApi := proxyapi.NewProxySender(chainID, wallet, contractLogStorage, sessionStorage, sessionRepo, appLog)
+	proxyRouterApi := proxyapi.NewProxySender(chainID, wallet, contractLogStorage, sessionStorage, sessionRepo, cfg.Proxy.CNodePNodeTimeout, cfg.Proxy.CNodePNodeMaxRetries, cfg.Proxy.CNodePNodeAudioMaxRetries, appLog)
 	explorer := blockchainapi.NewBlockscoutApiV2Client(cfg.Blockchain.BlockscoutApiUrl, log.Named("INDEXER"))
 	blockchainApi := blockchainapi.NewBlockchainService(ethClient, multicallBackend, *cfg.Marketplace.DiamondContractAddress, *cfg.Marketplace.MorTokenAddress, explorer, wallet, proxyRouterApi, sessionRepo, scorer, authCfg, appLog, rpcLog, cfg.Blockchain.EthLegacyTx)
 	proxyRouterApi.SetSessionService(blockchainApi)
@@ -300,7 +300,7 @@ func start() error {
 		appLog.Warnf("failed to load agent config, running with empty: %s", err)
 	}
 
-	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, appLog)
+	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, cfg.Proxy.LLMTimeout, appLog)
 
 	eventListener := blockchainapi.NewEventsListener(sessionRepo, sessionRouter, wallet, logWatcher, appLog)
 

--- a/proxy-router/internal/aiengine/factory.go
+++ b/proxy-router/internal/aiengine/factory.go
@@ -1,11 +1,15 @@
 package aiengine
 
-import "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+import (
+	"time"
 
-func ApiAdapterFactory(apiType string, modelName string, url string, apikey string, parameters ModelParameters, log lib.ILogger) (AIEngineStream, bool) {
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+func ApiAdapterFactory(apiType string, modelName string, url string, apikey string, parameters ModelParameters, llmTimeout time.Duration, log lib.ILogger) (AIEngineStream, bool) {
 	switch apiType {
 	case API_TYPE_OPENAI:
-		return NewOpenAIEngine(modelName, url, apikey, log), true
+		return NewOpenAIEngine(modelName, url, apikey, llmTimeout, log), true
 	case API_TYPE_PRODIA_SD:
 		return NewProdiaSDEngine(modelName, url, apikey, log), true
 	case API_TYPE_PRODIA_SDXL:
@@ -15,7 +19,7 @@ func ApiAdapterFactory(apiType string, modelName string, url string, apikey stri
 	case API_TYPE_HYPERBOLIC_SD:
 		return NewHyperbolicSDEngine(modelName, url, apikey, parameters, log), true
 	case API_TYPE_CLAUDEAI:
-		return NewClaudeAIEngine(modelName, url, apikey, log), true
+		return NewClaudeAIEngine(modelName, url, apikey, llmTimeout, log), true
 	}
 	return nil, false
 }

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -69,7 +69,11 @@ type Config struct {
 		RatingConfigPath    string    `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
 		CookieFilePath      string    `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
 		CookieContent       string    `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
-		AuthConfigFilePath  string    `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
+		AuthConfigFilePath   string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
+		LLMTimeout           time.Duration `env:"LLM_TIMEOUT" flag:"llm-timeout" validate:"omitempty" desc:"timeout for PNode to LLM requests, applies to both streaming and non-streaming"`
+		CNodePNodeTimeout         time.Duration `env:"CNODE_PNODE_TIMEOUT" flag:"cnode-pnode-timeout" validate:"omitempty" desc:"per-attempt timeout for CNode waiting for PNode first response"`
+		CNodePNodeMaxRetries      int           `env:"CNODE_PNODE_MAX_RETRIES" flag:"cnode-pnode-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (chat/embeddings)"`
+		CNodePNodeAudioMaxRetries int           `env:"CNODE_PNODE_AUDIO_MAX_RETRIES" flag:"cnode-pnode-audio-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (audio transcription/speech)"`
 	}
 	System struct {
 		Enable           bool   `env:"SYS_ENABLE"              flag:"sys-enable" desc:"enable system level configuration adjustments"`
@@ -186,6 +190,18 @@ func (cfg *Config) SetDefaults() {
 	if cfg.Proxy.AuthConfigFilePath == "" {
 		cfg.Proxy.AuthConfigFilePath = "./proxy.conf"
 	}
+	if cfg.Proxy.LLMTimeout == 0 {
+		cfg.Proxy.LLMTimeout = 240 * time.Second
+	}
+	if cfg.Proxy.CNodePNodeTimeout == 0 {
+		cfg.Proxy.CNodePNodeTimeout = 90 * time.Second
+	}
+	if cfg.Proxy.CNodePNodeMaxRetries == 0 {
+		cfg.Proxy.CNodePNodeMaxRetries = 3
+	}
+	if cfg.Proxy.CNodePNodeAudioMaxRetries == 0 {
+		cfg.Proxy.CNodePNodeAudioMaxRetries = 20
+	}
 
 	// IPFS
 	if cfg.IPFS.Address == "" {
@@ -231,6 +247,10 @@ func (cfg *Config) GetSanitized() interface{} {
 	publicCfg.Proxy.StoreChatContext = cfg.Proxy.StoreChatContext
 	publicCfg.Proxy.ForwardChatContext = cfg.Proxy.ForwardChatContext
 	publicCfg.Proxy.RatingConfigPath = cfg.Proxy.RatingConfigPath
+	publicCfg.Proxy.LLMTimeout = cfg.Proxy.LLMTimeout
+	publicCfg.Proxy.CNodePNodeTimeout = cfg.Proxy.CNodePNodeTimeout
+	publicCfg.Proxy.CNodePNodeMaxRetries = cfg.Proxy.CNodePNodeMaxRetries
+	publicCfg.Proxy.CNodePNodeAudioMaxRetries = cfg.Proxy.CNodePNodeAudioMaxRetries
 
 	publicCfg.System.Enable = cfg.System.Enable
 	publicCfg.System.LocalPortRange = cfg.System.LocalPortRange


### PR DESCRIPTION
## Summary

Adds configurable timeouts to close timeout gaps in the request chain (CNode -> PNode -> LLM).

Previously, PNode->LLM HTTP requests had **no timeout at all** (`http.Client{}` with zero timeout), and CNode->PNode had hardcoded 30s per-attempt with 5 retries. These are now configurable via environment variables with sensible defaults.

**New env vars:**

| Variable | Default | Description |
|----------|---------|-------------|
| `LLM_TIMEOUT` | `4m` | PNode to LLM timeout (streaming + non-streaming) |
| `CNODE_PNODE_TIMEOUT` | `90s` | Per-attempt timeout for CNode waiting on PNode |
| `CNODE_PNODE_MAX_RETRIES` | `3` | Retries for chat/embeddings (total: 4.5 min) |
| `CNODE_PNODE_AUDIO_MAX_RETRIES` | `20` | Retries for audio transcription/speech (total: 30 min) |

Supports Go duration strings: 30s, 5m, 1h, etc.
LLM_TIMEOUT=4m
