### PR TITLE
Configurable Timeouts & BadgerDB harding

### DIFF
--- a/proxy-router/.env.example
+++ b/proxy-router/.env.example
@@ -49,3 +49,17 @@ LOG_LEVEL_APP=warn
 LOG_LEVEL_TCP=warn
 LOG_LEVEL_ETH_RPC=warn
 LOG_LEVEL_STORAGE=warn
+
+# LLM Timeout: max duration for PNode to LLM requests (streaming and non-streaming)
+# Default: 4m (240 seconds). Supports Go duration strings: 30s, 5m, 1h, etc.
+LLM_TIMEOUT=4m
+
+# CNode to PNode timeout: per-attempt timeout waiting for PNode first response
+# Default: 90s. Supports Go duration strings: 30s, 5m, etc.
+CNODE_PNODE_TIMEOUT=90s
+#
+# Max retries for chat/embeddings (total budget = timeout * retries, default: 90s * 3 = 4.5 min)
+CNODE_PNODE_MAX_RETRIES=3
+#
+# Max retries for audio transcription/speech (default: 90s * 20 = 30 min)
+CNODE_PNODE_AUDIO_MAX_RETRIES=20

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -283,7 +283,7 @@ func start() error {
 	sessionRouter := registries.NewSessionRouter(*cfg.Marketplace.DiamondContractAddress, ethClient, multicallBackend, rpcLog)
 	marketplace := registries.NewMarketplace(*cfg.Marketplace.DiamondContractAddress, ethClient, multicallBackend, rpcLog)
 	sessionRepo := sessionrepo.NewSessionRepositoryCached(sessionStorage, sessionRouter, marketplace, appLog)
-	proxyRouterApi := proxyapi.NewProxySender(chainID, wallet, contractLogStorage, sessionStorage, sessionRepo, appLog)
+	proxyRouterApi := proxyapi.NewProxySender(chainID, wallet, contractLogStorage, sessionStorage, sessionRepo, cfg.Proxy.CNodePNodeTimeout, cfg.Proxy.CNodePNodeMaxRetries, cfg.Proxy.CNodePNodeAudioMaxRetries, appLog)
 	explorer := blockchainapi.NewBlockscoutApiV2Client(cfg.Blockchain.BlockscoutApiUrl, log.Named("INDEXER"))
 	blockchainApi := blockchainapi.NewBlockchainService(ethClient, multicallBackend, *cfg.Marketplace.DiamondContractAddress, *cfg.Marketplace.MorTokenAddress, explorer, wallet, proxyRouterApi, sessionRepo, scorer, authCfg, appLog, rpcLog, cfg.Blockchain.EthLegacyTx)
 	proxyRouterApi.SetSessionService(blockchainApi)
@@ -300,7 +300,7 @@ func start() error {
 		appLog.Warnf("failed to load agent config, running with empty: %s", err)
 	}
 
-	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, appLog)
+	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, cfg.Proxy.LLMTimeout, appLog)
 
 	eventListener := blockchainapi.NewEventsListener(sessionRepo, sessionRouter, wallet, logWatcher, appLog)
 

--- a/proxy-router/internal/aiengine/factory.go
+++ b/proxy-router/internal/aiengine/factory.go
@@ -1,11 +1,15 @@
 package aiengine
 
-import "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+import (
+	"time"
 
-func ApiAdapterFactory(apiType string, modelName string, url string, apikey string, parameters ModelParameters, log lib.ILogger) (AIEngineStream, bool) {
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+func ApiAdapterFactory(apiType string, modelName string, url string, apikey string, parameters ModelParameters, llmTimeout time.Duration, log lib.ILogger) (AIEngineStream, bool) {
 	switch apiType {
 	case API_TYPE_OPENAI:
-		return NewOpenAIEngine(modelName, url, apikey, log), true
+		return NewOpenAIEngine(modelName, url, apikey, llmTimeout, log), true
 	case API_TYPE_PRODIA_SD:
 		return NewProdiaSDEngine(modelName, url, apikey, log), true
 	case API_TYPE_PRODIA_SDXL:
@@ -15,7 +19,7 @@ func ApiAdapterFactory(apiType string, modelName string, url string, apikey stri
 	case API_TYPE_HYPERBOLIC_SD:
 		return NewHyperbolicSDEngine(modelName, url, apikey, parameters, log), true
 	case API_TYPE_CLAUDEAI:
-		return NewClaudeAIEngine(modelName, url, apikey, log), true
+		return NewClaudeAIEngine(modelName, url, apikey, llmTimeout, log), true
 	}
 	return nil, false
 }

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -69,7 +69,11 @@ type Config struct {
 		RatingConfigPath    string    `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
 		CookieFilePath      string    `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
 		CookieContent       string    `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
-		AuthConfigFilePath  string    `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
+		AuthConfigFilePath   string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
+		LLMTimeout           time.Duration `env:"LLM_TIMEOUT" flag:"llm-timeout" validate:"omitempty" desc:"timeout for PNode to LLM requests, applies to both streaming and non-streaming"`
+		CNodePNodeTimeout         time.Duration `env:"CNODE_PNODE_TIMEOUT" flag:"cnode-pnode-timeout" validate:"omitempty" desc:"per-attempt timeout for CNode waiting for PNode first response"`
+		CNodePNodeMaxRetries      int           `env:"CNODE_PNODE_MAX_RETRIES" flag:"cnode-pnode-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (chat/embeddings)"`
+		CNodePNodeAudioMaxRetries int           `env:"CNODE_PNODE_AUDIO_MAX_RETRIES" flag:"cnode-pnode-audio-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (audio transcription/speech)"`
 	}
 	System struct {
 		Enable           bool   `env:"SYS_ENABLE"              flag:"sys-enable" desc:"enable system level configuration adjustments"`
@@ -186,6 +190,18 @@ func (cfg *Config) SetDefaults() {
 	if cfg.Proxy.AuthConfigFilePath == "" {
 		cfg.Proxy.AuthConfigFilePath = "./proxy.conf"
 	}
+	if cfg.Proxy.LLMTimeout == 0 {
+		cfg.Proxy.LLMTimeout = 240 * time.Second
+	}
+	if cfg.Proxy.CNodePNodeTimeout == 0 {
+		cfg.Proxy.CNodePNodeTimeout = 90 * time.Second
+	}
+	if cfg.Proxy.CNodePNodeMaxRetries == 0 {
+		cfg.Proxy.CNodePNodeMaxRetries = 3
+	}
+	if cfg.Proxy.CNodePNodeAudioMaxRetries == 0 {
+		cfg.Proxy.CNodePNodeAudioMaxRetries = 20
+	}
 
 	// IPFS
 	if cfg.IPFS.Address == "" {
@@ -231,6 +247,10 @@ func (cfg *Config) GetSanitized() interface{} {
 	publicCfg.Proxy.StoreChatContext = cfg.Proxy.StoreChatContext
 	publicCfg.Proxy.ForwardChatContext = cfg.Proxy.ForwardChatContext
 	publicCfg.Proxy.RatingConfigPath = cfg.Proxy.RatingConfigPath
+	publicCfg.Proxy.LLMTimeout = cfg.Proxy.LLMTimeout
+	publicCfg.Proxy.CNodePNodeTimeout = cfg.Proxy.CNodePNodeTimeout
+	publicCfg.Proxy.CNodePNodeMaxRetries = cfg.Proxy.CNodePNodeMaxRetries
+	publicCfg.Proxy.CNodePNodeAudioMaxRetries = cfg.Proxy.CNodePNodeAudioMaxRetries
 
 	publicCfg.System.Enable = cfg.System.Enable
 	publicCfg.System.LocalPortRange = cfg.System.LocalPortRange

--- a/proxy-router/internal/proxyapi/capacity_manager.go
+++ b/proxy-router/internal/proxyapi/capacity_manager.go
@@ -39,8 +39,12 @@ func (scm *SimpleCapacityManager) HasCapacity(modelID string) bool {
 
 	activeSessions := 0
 	for _, session := range sessions {
-		s, ok := scm.storage.GetSession(session)
-		if !ok {
+		s, err := scm.storage.GetSession(session)
+		if err != nil {
+			scm.log.Warnf("error reading session %s: %s", session, err)
+			continue
+		}
+		if s == nil {
 			continue
 		}
 		if s.EndsAt.Int64() > time.Now().Unix() {
@@ -80,8 +84,12 @@ func (idcm *IdleTimeoutCapacityManager) HasCapacity(modelID string) bool {
 
 	activeSessions := 0
 	for _, activity := range activities {
-		session, ok := idcm.storage.GetSession(activity.SessionID)
-		if !ok {
+		session, err := idcm.storage.GetSession(activity.SessionID)
+		if err != nil {
+			idcm.log.Warnf("error reading session %s: %s", activity.SessionID, err)
+			continue
+		}
+		if session == nil {
 			continue
 		}
 		if session.EndsAt.Int64() < time.Now().Unix() {

--- a/proxy-router/internal/proxyapi/controller_morrpc.go
+++ b/proxy-router/internal/proxyapi/controller_morrpc.go
@@ -148,8 +148,11 @@ func (s *MORRPCController) sessionPrompt(ctx context.Context, msg m.RPCMessage, 
 		return err
 	}
 
-	user, ok := s.sessionStorage.GetUser(session.UserAddr().Hex())
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr().Hex())
+	if err != nil {
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		return fmt.Errorf("user not found")
 	}
 
@@ -216,15 +219,23 @@ func (s *MORRPCController) sessionReport(ctx context.Context, msg m.RPCMessage, 
 
 	sessionID := req.Message
 	sourceLog.Debugf("Requested report from session %s, timestamp: %s", sessionID, req.Timestamp)
-	session, ok := s.sessionStorage.GetSession(sessionID)
-	if !ok {
+	session, err := s.sessionStorage.GetSession(sessionID)
+	if err != nil {
+		sourceLog.Errorf("error reading session: %s", err)
+		return fmt.Errorf("error reading session: %w", err)
+	}
+	if session == nil {
 		err := fmt.Errorf("session not found")
 		sourceLog.Error(err)
 		return err
 	}
 
-	user, ok := s.sessionStorage.GetUser(session.UserAddr)
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr)
+	if err != nil {
+		sourceLog.Errorf("error reading user: %s", err)
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		err := fmt.Errorf("user not found")
 		sourceLog.Error(err)
 		return err
@@ -271,8 +282,11 @@ func (s *MORRPCController) callAgentTool(ctx context.Context, msg m.RPCMessage, 
 		return err
 	}
 
-	user, ok := s.sessionStorage.GetUser(session.UserAddr().Hex())
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr().Hex())
+	if err != nil {
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		return fmt.Errorf("user not found")
 	}
 
@@ -317,8 +331,11 @@ func (s *MORRPCController) getAgentTools(ctx context.Context, msg m.RPCMessage, 
 		return err
 	}
 
-	user, ok := s.sessionStorage.GetUser(session.UserAddr().Hex())
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr().Hex())
+	if err != nil {
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		return fmt.Errorf("user not found")
 	}
 
@@ -364,8 +381,11 @@ func (s *MORRPCController) sessionPromptStreamStart(ctx context.Context, msg m.R
 	}
 
 	// Verify user signature
-	user, ok := s.sessionStorage.GetUser(session.UserAddr().Hex())
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr().Hex())
+	if err != nil {
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		return fmt.Errorf("user not found")
 	}
 
@@ -429,8 +449,11 @@ func (s *MORRPCController) sessionPromptStreamChunk(ctx context.Context, msg m.R
 	}
 
 	// Verify user signature
-	user, ok := s.sessionStorage.GetUser(session.UserAddr().Hex())
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr().Hex())
+	if err != nil {
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		return fmt.Errorf("user not found")
 	}
 
@@ -512,8 +535,11 @@ func (s *MORRPCController) sessionPromptStreamEnd(ctx context.Context, msg m.RPC
 	}
 
 	// Verify user signature
-	user, ok := s.sessionStorage.GetUser(session.UserAddr().Hex())
-	if !ok {
+	user, err := s.sessionStorage.GetUser(session.UserAddr().Hex())
+	if err != nil {
+		return fmt.Errorf("error reading user: %w", err)
+	}
+	if user == nil {
 		return fmt.Errorf("user not found")
 	}
 

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -202,8 +202,11 @@ func (p *ProxyServiceSender) GetSessionReportFromProvider(ctx context.Context, s
 	if err != nil {
 		return nil, ErrSessionNotFound
 	}
-	provider, ok := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
-	if !ok {
+	provider, err := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
+	if err != nil {
+		return nil, fmt.Errorf("error reading provider: %w", err)
+	}
+	if provider == nil {
 		return nil, ErrProviderNotFound
 	}
 
@@ -317,8 +320,11 @@ func (p *ProxyServiceSender) CallAgentTool(ctx context.Context, sessionID common
 		return "", ErrSessionExpired
 	}
 
-	provider, ok := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
-	if !ok {
+	provider, err := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
+	if err != nil {
+		return "", fmt.Errorf("error reading provider: %w", err)
+	}
+	if provider == nil {
 		return "", ErrProviderNotFound
 	}
 
@@ -384,8 +390,11 @@ func (p *ProxyServiceSender) GetAgentTools(ctx context.Context, sessionID common
 		return "", ErrSessionExpired
 	}
 
-	provider, ok := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
-	if !ok {
+	provider, err := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
+	if err != nil {
+		return "", fmt.Errorf("error reading provider: %w", err)
+	}
+	if provider == nil {
 		return "", ErrProviderNotFound
 	}
 
@@ -503,8 +512,11 @@ func (p *ProxyServiceSender) validateSession(ctx context.Context, sessionID comm
 	}
 
 	// Get provider information
-	provider, ok := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
-	if !ok {
+	provider, err := p.sessionStorage.GetUser(session.ProviderAddr().Hex())
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading provider: %w", err)
+	}
+	if provider == nil {
 		return nil, nil, ErrProviderNotFound
 	}
 

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -53,27 +53,33 @@ const (
 )
 
 type ProxyServiceSender struct {
-	chainID        *big.Int
-	privateKey     interfaces.PrKeyProvider
-	logStorage     *lib.Collection[*interfaces.LogStorage]
-	sessionStorage *storages.SessionStorage
-	sessionRepo    *sessionrepo.SessionRepositoryCached
-	morRPC         *msgs.MORRPCMessage
-	sessionService SessionService
-	sessionSema    *SessionSemaphore // Limits to 1 concurrent request per session
-	log            lib.ILogger
+	chainID              *big.Int
+	privateKey           interfaces.PrKeyProvider
+	logStorage           *lib.Collection[*interfaces.LogStorage]
+	sessionStorage       *storages.SessionStorage
+	sessionRepo          *sessionrepo.SessionRepositoryCached
+	morRPC               *msgs.MORRPCMessage
+	sessionService       SessionService
+	sessionSema          *SessionSemaphore // Limits to 1 concurrent request per session
+	cnodePnodeTimeout         time.Duration // Per-attempt timeout waiting for PNode first response
+	cnodePnodeMaxRetries      int           // Max retries on read timeout from PNode (chat/embeddings)
+	cnodePnodeAudioMaxRetries int           // Max retries on read timeout from PNode (audio)
+	log                       lib.ILogger
 }
 
-func NewProxySender(chainID *big.Int, privateKey interfaces.PrKeyProvider, logStorage *lib.Collection[*interfaces.LogStorage], sessionStorage *storages.SessionStorage, sessionRepo *sessionrepo.SessionRepositoryCached, log lib.ILogger) *ProxyServiceSender {
+func NewProxySender(chainID *big.Int, privateKey interfaces.PrKeyProvider, logStorage *lib.Collection[*interfaces.LogStorage], sessionStorage *storages.SessionStorage, sessionRepo *sessionrepo.SessionRepositoryCached, cnodePnodeTimeout time.Duration, cnodePnodeMaxRetries int, cnodePnodeAudioMaxRetries int, log lib.ILogger) *ProxyServiceSender {
 	return &ProxyServiceSender{
-		chainID:        chainID,
-		privateKey:     privateKey,
-		logStorage:     logStorage,
-		sessionStorage: sessionStorage,
-		sessionRepo:    sessionRepo,
-		morRPC:         msgs.NewMorRpc(),
-		sessionSema:    NewSessionSemaphore(),
-		log:            log,
+		chainID:                   chainID,
+		privateKey:                privateKey,
+		logStorage:                logStorage,
+		sessionStorage:            sessionStorage,
+		sessionRepo:               sessionRepo,
+		morRPC:                    msgs.NewMorRpc(),
+		sessionSema:               NewSessionSemaphore(),
+		cnodePnodeTimeout:         cnodePnodeTimeout,
+		cnodePnodeMaxRetries:      cnodePnodeMaxRetries,
+		cnodePnodeAudioMaxRetries: cnodePnodeAudioMaxRetries,
+		log:                       log,
 	}
 }
 
@@ -665,13 +671,12 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 	requestType string,
 	promptTokens int,
 ) (interface{}, int, int, int, error) {
-	const (
-		TIMEOUT_TO_ESTABLISH_CONNECTION   = time.Second * 3
-		TIMEOUT_TO_RECEIVE_FIRST_RESPONSE = time.Second * 30
-	)
-	var MAX_RETRIES = 5
+	const TIMEOUT_TO_ESTABLISH_CONNECTION = time.Second * 3
+
+	timeoutPerAttempt := p.cnodePnodeTimeout
+	maxRetries := p.cnodePnodeMaxRetries
 	if requestType == "audio_transcription" || requestType == "audio_speech" {
-		MAX_RETRIES = 20 // Increase retries for audio transcription
+		maxRetries = p.cnodePnodeAudioMaxRetries
 	}
 
 	dialer := net.Dialer{Timeout: TIMEOUT_TO_ESTABLISH_CONNECTION}
@@ -702,7 +707,7 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 	}
 
 	// Set initial read deadline
-	_ = conn.SetReadDeadline(time.Now().Add(TIMEOUT_TO_RECEIVE_FIRST_RESPONSE))
+	_ = conn.SetReadDeadline(time.Now().Add(timeoutPerAttempt))
 
 	msgJSON, err := json.Marshal(rpcMessage)
 	if err != nil {
@@ -746,8 +751,8 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				p.log.Warnf("Read operation timed out: %v", err)
-				p.log.Infof("Retry count: %d, max retries: %d", retryCount, MAX_RETRIES)
-				if retryCount < MAX_RETRIES {
+				p.log.Infof("Retry count: %d, max retries: %d", retryCount, maxRetries)
+				if retryCount < maxRetries {
 					alive, availErr := checkProviderAvailability(url)
 					if availErr != nil {
 						p.log.Warnf("Provider availability check failed: %v", availErr)
@@ -755,9 +760,9 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 					}
 					if alive {
 						retryCount++
-						p.log.Infof("Provider is alive, retrying (%d/%d)...", retryCount, MAX_RETRIES)
+						p.log.Infof("Provider is alive, retrying (%d/%d)...", retryCount, maxRetries)
 						// Reset the read deadline
-						conn.SetReadDeadline(time.Now().Add(TIMEOUT_TO_RECEIVE_FIRST_RESPONSE))
+						conn.SetReadDeadline(time.Now().Add(timeoutPerAttempt))
 						// Clear the error state by reading any remaining data
 						reader.Discard(reader.Buffered())
 						// Reset the decoder

--- a/proxy-router/internal/storages/session_storage_test.go
+++ b/proxy-router/internal/storages/session_storage_test.go
@@ -25,8 +25,9 @@ func TestAddSession(t *testing.T) {
 	err := sessionStorage.AddSession(session)
 	require.NoError(t, err)
 
-	s, ok := sessionStorage.GetSession(session.Id)
-	require.True(t, ok)
+	s, err := sessionStorage.GetSession(session.Id)
+	require.NoError(t, err)
+	require.NotNil(t, s)
 	require.Equal(t, session, s)
 
 	sessionIds, err := sessionStorage.GetSessionsForModel(session.ModelID)
@@ -55,8 +56,9 @@ func TestRemoveSession(t *testing.T) {
 	err = sessionStorage.RemoveSession(session.Id)
 	require.NoError(t, err)
 
-	_, ok := sessionStorage.GetSession(session.Id)
-	require.False(t, ok)
+	s, err := sessionStorage.GetSession(session.Id)
+	require.NoError(t, err)
+	require.Nil(t, s)
 
 	sessionIds, err := sessionStorage.GetSessionsForModel(session.ModelID)
 	require.NoError(t, err)

--- a/proxy-router/internal/storages/storage.go
+++ b/proxy-router/internal/storages/storage.go
@@ -1,6 +1,9 @@
 package storages
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -8,46 +11,51 @@ import (
 	badger "github.com/dgraph-io/badger/v4"
 )
 
+// Default configuration values for BadgerDB
+const (
+	DefaultGCInterval      = 5 * time.Minute
+	DefaultGCRatio         = 0.5
+	DefaultMetricsInterval = 5 * time.Minute
+)
+
 type Storage struct {
-	db *badger.DB
+	db     *badger.DB
+	log    lib.ILogger
 	stopGC chan struct{}
 	gcDone chan struct{}
 }
 
-func NewStorage(log lib.ILogger, path string) *Storage {
+// NewStorage opens a BadgerDB at the given path and starts background GC.
+// Returns an error instead of calling log.Fatal so callers can handle failures gracefully.
+func NewStorage(log lib.ILogger, path string) (*Storage, error) {
 	storageLogger := NewStorageLogger(log)
-	if err := os.Mkdir(path, os.ModePerm); err != nil {
-		storageLogger.Debugf("%s", err)
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create storage directory %s: %w", path, err)
 	}
+
 	opts := badger.DefaultOptions(path)
 	opts.Logger = storageLogger
+	opts.NumVersionsToKeep = 1
+	opts.CompactL0OnClose = true
 
 	db, err := badger.Open(opts)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("failed to open badger db at %s: %w", path, err)
 	}
 
-	s := &Storage{db: db, stopGC: make(chan struct{}), gcDone: make(chan struct{})}
-	go func() {
-		defer close(s.gcDone)
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-s.stopGC:
-				return
-			case <-ticker.C:
-				for {
-					if err := db.RunValueLogGC(0.7); err != nil {
-						break
-					}
-				}
-			}
-		}
-	}()
-	return s
+	s := &Storage{
+		db:     db,
+		log:    log.Named("BADGER"),
+		stopGC: make(chan struct{}),
+		gcDone: make(chan struct{}),
+	}
+	s.startGC(db, DefaultGCRatio, DefaultGCInterval)
+	s.startMetrics(DefaultMetricsInterval)
+
+	return s, nil
 }
 
+// NewTestStorage creates an in-memory storage for testing.
 func NewTestStorage() *Storage {
 	opts := badger.DefaultOptions("")
 	opts.InMemory = true
@@ -58,16 +66,111 @@ func NewTestStorage() *Storage {
 	return &Storage{db: db, stopGC: make(chan struct{}), gcDone: make(chan struct{})}
 }
 
-func (s *Storage) Close() {
+// Close stops GC, flushes data, and closes the underlying BadgerDB.
+func (s *Storage) Close() error {
 	if s.stopGC != nil {
 		close(s.stopGC)
 		if s.gcDone != nil {
 			<-s.gcDone
 		}
 	}
-	s.db.Close()
+	if err := s.db.Close(); err != nil {
+		if s.log != nil {
+			s.log.Errorf("error closing badger db: %s", err)
+		}
+		return fmt.Errorf("error closing badger db: %w", err)
+	}
+	return nil
 }
 
+// startGC runs periodic value log garbage collection in the background.
+func (s *Storage) startGC(db *badger.DB, discardRatio float64, interval time.Duration) {
+	go func() {
+		defer close(s.gcDone)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.stopGC:
+				return
+			case <-ticker.C:
+				gcRuns := 0
+				for {
+					err := db.RunValueLogGC(discardRatio)
+					if err != nil {
+						if !errors.Is(err, badger.ErrNoRewrite) {
+							s.log.Warnf("badger GC error: %s", err)
+						}
+						break
+					}
+					gcRuns++
+				}
+
+				lsmSize, vlogSize := db.Size()
+				totalMB := float64(lsmSize+vlogSize) / (1024 * 1024)
+				if gcRuns > 0 {
+					s.log.Infof("badger GC completed: %d cycles, lsm=%.1fMB, vlog=%.1fMB, total=%.1fMB",
+						gcRuns, float64(lsmSize)/(1024*1024), float64(vlogSize)/(1024*1024), totalMB)
+				} else {
+					s.log.Infof("badger GC: ok, nothing to clean, lsm=%.1fMB, vlog=%.1fMB, total=%.1fMB",
+						float64(lsmSize)/(1024*1024), float64(vlogSize)/(1024*1024), totalMB)
+				}
+			}
+		}
+	}()
+}
+
+// startMetrics periodically logs database size metrics.
+func (s *Storage) startMetrics(interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.stopGC:
+				return
+			case <-ticker.C:
+				lsmSize, vlogSize := s.db.Size()
+				totalMB := float64(lsmSize+vlogSize) / (1024 * 1024)
+				if totalMB > 10000 {
+					s.log.Warnf("badger DB size is large: lsm=%.1fMB, vlog=%.1fMB, total=%.1fMB",
+						float64(lsmSize)/(1024*1024), float64(vlogSize)/(1024*1024), totalMB)
+				}
+			}
+		}
+	}()
+}
+
+// HealthCheck verifies the database is operational by doing a test write/read/delete cycle.
+func (s *Storage) HealthCheck() error {
+	testKey := []byte("_health_check")
+	testVal := []byte(time.Now().Format(time.RFC3339Nano))
+
+	if err := s.Set(testKey, testVal); err != nil {
+		return fmt.Errorf("badger health check write failed: %w", err)
+	}
+
+	readVal, err := s.Get(testKey)
+	if err != nil {
+		return fmt.Errorf("badger health check read failed: %w", err)
+	}
+	if string(readVal) != string(testVal) {
+		return fmt.Errorf("badger health check mismatch: wrote %q, read %q", testVal, readVal)
+	}
+
+	if err := s.Delete(testKey); err != nil {
+		return fmt.Errorf("badger health check delete failed: %w", err)
+	}
+
+	return nil
+}
+
+// DBSize returns the LSM and value log sizes in bytes.
+func (s *Storage) DBSize() (lsmSize int64, vlogSize int64) {
+	return s.db.Size()
+}
+
+// Get retrieves the value for the given key. Returns badger.ErrKeyNotFound if the key does not exist.
 func (s *Storage) Get(key []byte) ([]byte, error) {
 	var valCopy []byte
 	err := s.db.View(func(txn *badger.Txn) error {
@@ -88,6 +191,7 @@ func (s *Storage) Get(key []byte) ([]byte, error) {
 	return valCopy, err
 }
 
+// GetPrefix returns all keys matching the given prefix.
 func (s *Storage) GetPrefix(prefix []byte) ([][]byte, error) {
 	keys := make([][]byte, 0)
 	err := s.db.View(func(txn *badger.Txn) error {
@@ -104,18 +208,69 @@ func (s *Storage) GetPrefix(prefix []byte) ([][]byte, error) {
 	return keys, err
 }
 
+// GetPrefixWithValues returns all key-value pairs matching the given prefix in a single transaction.
+// Supports context cancellation for long-running scans.
+func (s *Storage) GetPrefixWithValues(prefix []byte, ctxOpts ...context.Context) ([][]byte, [][]byte, error) {
+	var ctx context.Context
+	if len(ctxOpts) > 0 && ctxOpts[0] != nil {
+		ctx = ctxOpts[0]
+	}
+
+	var keys [][]byte
+	var values [][]byte
+	err := s.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.IteratorOptions{PrefetchValues: true, PrefetchSize: 100, Prefix: prefix})
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if ctx != nil {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("scan cancelled: %w", err)
+				}
+			}
+			item := it.Item()
+			k := item.KeyCopy(nil)
+			v, err := item.ValueCopy(nil)
+			if err != nil {
+				return fmt.Errorf("error reading value for key %s: %w", string(k), err)
+			}
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+		return nil
+	})
+	return keys, values, err
+}
+
+// Set stores a key-value pair.
 func (s *Storage) Set(key, val []byte) error {
 	return s.db.Update(func(txn *badger.Txn) error {
 		return txn.Set(key, val)
 	})
 }
 
+// SetWithTTL stores a key-value pair that expires after the given duration.
+func (s *Storage) SetWithTTL(key, val []byte, ttl time.Duration) error {
+	return s.db.Update(func(txn *badger.Txn) error {
+		entry := badger.NewEntry(key, val).WithTTL(ttl)
+		return txn.SetEntry(entry)
+	})
+}
+
+// Delete removes a key from the database.
 func (s *Storage) Delete(key []byte) error {
 	return s.db.Update(func(txn *badger.Txn) error {
 		return txn.Delete(key)
 	})
 }
 
+// RunInTransaction executes a function within a single read-write BadgerDB transaction.
+// This is used for atomic read-modify-write operations.
+func (s *Storage) RunInTransaction(fn func(txn *badger.Txn) error) error {
+	return s.db.Update(fn)
+}
+
+// Paginate returns keys matching the prefix with cursor-based pagination.
 func (s *Storage) Paginate(prefix []byte, cursor []byte, limit uint) ([][]byte, []byte, error) {
 	keys := make([][]byte, 0, limit)
 	var nextCursor []byte

--- a/proxy-router/internal/system/structs.go
+++ b/proxy-router/internal/system/structs.go
@@ -17,9 +17,10 @@ type ConfigResponse struct {
 }
 
 type HealthCheckResponse struct {
-	Status  string
-	Version string
-	Uptime  string
+	Status     string            `json:"status"`
+	Version    string            `json:"version"`
+	Uptime     string            `json:"uptime"`
+	Components map[string]string `json:"components,omitempty"`
 }
 
 type StatusRes struct {

--- a/proxy-router/test/httphandlers_test.go
+++ b/proxy-router/test/httphandlers_test.go
@@ -288,7 +288,12 @@ func InitializeApiBus(t *testing.T) *apibus.APIBus {
 
 	contractLogStorage := lib.NewCollection[*interfaces.LogStorage]()
 
-	storage := storages.NewStorage(log, "data/test/")
+	storage, err := storages.NewStorage(log, "data/test/")
+	if err != nil {
+		t.Fatalf("failed to initialize storage: %s", err)
+		return nil
+	}
+	defer storage.Close()
 	sessionStorage := storages.NewSessionStorage(storage)
 
 	wlt := wallet.NewEnvWallet(WALLET_PRIVATE_KEY)


### PR DESCRIPTION
## Summary  - Adds configurable timeouts to close timeout gaps in the request chain (CNode -> PNode -> LLM).

Previously, Provider Node->LLM HTTP requests had **no timeout at all** (`http.Client{}` with zero timeout), and Consumer Node->Provider Node had hardcoded 30s per-attempt with 5 retries. These are now configurable via environment variables with sensible defaults.

**New env vars:**

| Variable | Default | Description |
|----------|---------|-------------|
| `LLM_TIMEOUT` | `4m` | PNode to LLM timeout (streaming + non-streaming) |
| `CNODE_PNODE_TIMEOUT` | `90s` | Per-attempt timeout for CNode waiting on PNode |
| `CNODE_PNODE_MAX_RETRIES` | `3` | Retries for chat/embeddings (total: 4.5 min) |
| `CNODE_PNODE_AUDIO_MAX_RETRIES` | `20` | Retries for audio transcription/speech (total: 30 min) |

Supports Go duration strings: 30s, 5m, 1h, etc.
LLM_TIMEOUT=4m





## Summary: Comprehensive hardening of the BadgerDB storage layer

### Critical fixes

- **Storage never closed on shutdown** -- added `defer storage.Close()` in main.go. Previously, BadgerDB WAL was never flushed on ECS task kill, likely contributing to vlog corruption.
- **Race condition in AddActivity / RemoveOldActivities** -- read-modify-write across separate transactions caused silent activity loss under concurrent prompts. Now uses single atomic BadgerDB transactions.
- **Race condition in SetAllowance** -- same read-modify-write pattern. Now atomic.
- **Non-atomic AddSession** -- session data and model-session index were written in two separate transactions. If the second failed, DB had orphaned data. Now a single transaction.
- **Non-atomic RemoveSession** -- same issue, now atomic.
- **NewStorage called log.Fatal on failure** -- now returns an error so callers can handle gracefully.
- **os.Mkdir replaced with os.MkdirAll** -- nested storage paths no longer fail silently.

### Observability improvements

- **GC logging** -- every 5-minute GC tick now logs: cycle count, errors, and DB size in MB. No more silent GC. Three states: error (Warn), cleaned (Info), nothing to clean (Info).
- **GC errors classified** -- `ErrNoRewrite` (normal/expected) is distinguished from real errors. Real errors logged as warnings.
- **Periodic DB size metrics** -- warns when total DB size exceeds 10GB.
- **Health check endpoint** -- `/healthcheck` now includes BadgerDB status: performs a write/read/delete cycle and reports DB size. Returns 503 when storage is unhealthy.
- **Structured error handling** -- getter methods (`GetSession`, `GetUser`, `GetAgentUser`, `GetAllowanceRequest`) now return `(*T, error)` instead of `(*T, bool)`. Distinguishes `ErrKeyNotFound` (normal) from corruption/IO errors. Corruption errors are no longer silently swallowed as "not found".
- **Close() returns error** -- DB close failures are logged and returned instead of silently discarded.

### Data management

- **TTL on activities** -- 24h expiration prevents unbounded accumulation (primary driver of the 69GB growth).
- **TTL on sessions** -- 30-day expiration as safety net alongside the session expiry handler.
- **GC discard ratio lowered from 0.7 to 0.5** -- allows GC to reclaim vlogs with 50%+ garbage instead of requiring 70%, improving cleanup under continuous write load.

### Performance

- **N+1 query elimination** -- `GetSessions`, `GetAgentUsers`, `GetAllowanceRequests` now use a single-transaction scan (`GetPrefixWithValues`) instead of fetching keys then reading each value individually.
- **BadgerDB tuning** -- `NumVersionsToKeep=1` (no versioning needed), `CompactL0OnClose=true` (ensures compaction on shutdown).
- **Context propagation** -- `GetSessions` accepts optional context for cancellation during large scans (used by session expiry handler).

### Session expiry handler

- `RemoveSession` errors are now logged instead of silently discarded.
- Passes context to `GetSessions` for clean cancellation on shutdown.

---