### PR TITLE
feat: generate random request IDs and promote debug logs to info for …

### DIFF
--- a/proxy-router/internal/aiengine/claudeai.go
+++ b/proxy-router/internal/aiengine/claudeai.go
@@ -124,7 +124,7 @@ func (a *ClaudeAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionReques
 	defer resp.Body.Close()
 
 	log := a.log.With("request_id", lib.RequestIDFromContext(ctx))
-	log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
+	log.Infof("AI Model responded with status code: %d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
 		return a.readError(ctx, resp.Body, cb)
 	}

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -78,7 +78,7 @@ func (a *OpenAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionRequestE
 	defer resp.Body.Close()
 
 	log := a.log.With("request_id", lib.RequestIDFromContext(ctx))
-	log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
+	log.Infof("AI Model responded with status code: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
 		log.Warnf("AI Model responded with error: %s", resp.StatusCode)
@@ -218,7 +218,7 @@ func (a *OpenAI) readTranscriptionStream(ctx context.Context, body io.Reader, cb
 				return fmt.Errorf("transcription error: %v", errorMsg)
 
 			default:
-				a.log.With("request_id", lib.RequestIDFromContext(ctx)).Debugf("Received transcription event: %s", eventType)
+				a.log.With("request_id", lib.RequestIDFromContext(ctx)).Infof("Received transcription event: %s", eventType)
 			}
 		}
 	}

--- a/proxy-router/internal/handlers/httphandlers/logging.go
+++ b/proxy-router/internal/handlers/httphandlers/logging.go
@@ -15,7 +15,7 @@ func RequestLogger(logger lib.ILogger) gin.HandlerFunc {
 		raw := c.Request.URL.RawQuery
 
 		start := time.Now()
-		logger.Debugf("[HTTP-REQ] %s %s",
+		logger.Infof("[HTTP-REQ] %s %s",
 			c.Request.Method,
 			path,
 		)
@@ -30,11 +30,13 @@ func RequestLogger(logger lib.ILogger) gin.HandlerFunc {
 		// Log details
 		status := c.Writer.Status()
 		latency := time.Since(start).Round(time.Millisecond)
-		logger.Debugf("[HTTP-RES] %s %s [%d] %v",
+		requestID, _ := c.Get("request_id")
+		logger.Infof("[HTTP-RES] %s %s [%d] %v request_id=%v",
 			c.Request.Method,
 			path,
 			status,
 			latency,
+			requestID,
 		)
 	}
 }

--- a/proxy-router/internal/handlers/tcphandlers/tcp.go
+++ b/proxy-router/internal/handlers/tcphandlers/tcp.go
@@ -46,7 +46,7 @@ func NewTCPHandler(
 		sourceLog = sourceLog.With("request_id", msg.ID)
 
 		err = morRpcHandler.Handle(ctx, *msg, sourceLog, func(resp *morrpc.RpcResponse) error {
-			sourceLog.Debugf("sending TCP response for method: %s", msg.Method)
+			sourceLog.Infof("sending TCP response for method: %s", msg.Method)
 			_, err := sendMsg(conn, resp)
 			if err != nil {
 				sourceLog.Errorf("Error sending message: %s", err)

--- a/proxy-router/internal/lib/context.go
+++ b/proxy-router/internal/lib/context.go
@@ -1,6 +1,17 @@
 package lib
 
-import "context"
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// GenerateRequestID returns a random 8-character hex string for use as a request ID.
+func GenerateRequestID() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
 
 type contextKey string
 

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -195,7 +195,7 @@ func (c *ProxyController) Prompt(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))
@@ -1381,7 +1381,7 @@ func (c *ProxyController) AudioTranscription(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))
@@ -1562,7 +1562,7 @@ func (c *ProxyController) AudioSpeech(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))
@@ -1699,7 +1699,7 @@ func (c *ProxyController) Embeddings(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -331,16 +331,16 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 
 	// Process request with appropriate adapter method
 	if audioTranscriptionReq != nil {
-		sourceLog.Debugf("Processing audio transcription request")
+		sourceLog.Infof("Processing audio transcription request")
 		err = adapter.AudioTranscription(ctx, audioTranscriptionReq, cb)
 	} else if audioSpeechReq != nil {
-		sourceLog.Debugf("Processing audio speech request")
+		sourceLog.Infof("Processing audio speech request")
 		err = adapter.AudioSpeech(ctx, audioSpeechReq, cb)
 	} else if embeddingsReq != nil {
-		sourceLog.Debugf("Processing embeddings request")
+		sourceLog.Infof("Processing embeddings request")
 		err = adapter.Embeddings(ctx, embeddingsReq, cb)
 	} else {
-		sourceLog.Debugf("Processing chat completion request")
+		sourceLog.Infof("Processing chat completion request")
 		err = adapter.Prompt(ctx, chatReq, cb)
 	}
 
@@ -355,7 +355,7 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 }
 
 func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID string, req *m.SessionReq, log lib.ILogger) (*msg.RpcResponse, error) {
-	log.Debugf("Received session request from %s, timestamp: %s", req.User, req.Timestamp)
+	log.Infof("Received session request from %s, timestamp: %s", req.User, req.Timestamp)
 
 	bid, err := s.service.GetBidByID(ctx, req.BidID)
 	if err != nil {
@@ -406,7 +406,7 @@ func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID 
 }
 
 func (s *ProxyReceiver) SessionReport(ctx context.Context, msgID string, reqID string, session *storages.Session, sourceLog lib.ILogger) (*msg.RpcResponse, error) {
-	sourceLog.Debugf("received session report request for %s", session.Id)
+	sourceLog.Infof("received session report request for %s", session.Id)
 
 	tps := 0
 	ttft := 0
@@ -444,7 +444,7 @@ func (s *ProxyReceiver) SessionReport(ctx context.Context, msgID string, reqID s
 }
 
 func (s *ProxyReceiver) CallAgentTool(ctx context.Context, msgID string, reqID string, userPubKey string, req *m.CallAgentToolReq, sourceLog lib.ILogger) (*msg.RpcResponse, error) {
-	sourceLog.Debugf("received call agent tool request for %s", req.SessionID)
+	sourceLog.Infof("received call agent tool request for %s", req.SessionID)
 
 	var input map[string]interface{}
 
@@ -496,7 +496,7 @@ func (s *ProxyReceiver) CallAgentTool(ctx context.Context, msgID string, reqID s
 }
 
 func (s *ProxyReceiver) GetAgentTools(ctx context.Context, msgID string, reqID string, userPubKey string, req *m.GetAgentToolsReq, sourceLog lib.ILogger) (*msg.RpcResponse, error) {
-	sourceLog.Debugf("received get agent tools request for %s", req.SessionID)
+	sourceLog.Infof("received get agent tools request for %s", req.SessionID)
 
 	session, err := s.sessionRepo.GetSession(ctx, req.SessionID)
 	if err != nil {


### PR DESCRIPTION
…request tracing

## Summary

- Replace hardcoded default request ID `"1"` with randomly generated 8-char hex IDs (`GenerateRequestID()`) so every request gets a unique identifier for tracing
- Promote all non-sensitive `Debug` logs in the request handling paths (chat completions, audio transcription, audio speech, embeddings) to `Info` level for production visibility
- Add `request_id` to the HTTP response log middleware (`[HTTP-RES]`) so request IDs appear in access logs
