### PR TITLE
Fix Approve Overflow & Improve logging - MAIN

### DIFF
--- a/proxy-router/internal/aiengine/claudeai.go
+++ b/proxy-router/internal/aiengine/claudeai.go
@@ -123,7 +123,8 @@ func (a *ClaudeAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionReques
 	}
 	defer resp.Body.Close()
 
-	a.log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
+	log := a.log.With("request_id", lib.RequestIDFromContext(ctx))
+	log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
 		return a.readError(ctx, resp.Body, cb)
 	}

--- a/proxy-router/internal/aiengine/claudeai.go
+++ b/proxy-router/internal/aiengine/claudeai.go
@@ -124,7 +124,7 @@ func (a *ClaudeAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionReques
 	defer resp.Body.Close()
 
 	log := a.log.With("request_id", lib.RequestIDFromContext(ctx))
-	log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
+	log.Infof("AI Model responded with status code: %d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
 		return a.readError(ctx, resp.Body, cb)
 	}

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -78,7 +78,7 @@ func (a *OpenAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionRequestE
 	defer resp.Body.Close()
 
 	log := a.log.With("request_id", lib.RequestIDFromContext(ctx))
-	log.Debugf("AI Model responded with status code: %d", resp.StatusCode)
+	log.Infof("AI Model responded with status code: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
 		log.Warnf("AI Model responded with error: %s", resp.StatusCode)
@@ -218,7 +218,7 @@ func (a *OpenAI) readTranscriptionStream(ctx context.Context, body io.Reader, cb
 				return fmt.Errorf("transcription error: %v", errorMsg)
 
 			default:
-				a.log.With("request_id", lib.RequestIDFromContext(ctx)).Debugf("Received transcription event: %s", eventType)
+				a.log.With("request_id", lib.RequestIDFromContext(ctx)).Infof("Received transcription event: %s", eventType)
 			}
 		}
 	}

--- a/proxy-router/internal/handlers/httphandlers/logging.go
+++ b/proxy-router/internal/handlers/httphandlers/logging.go
@@ -15,7 +15,7 @@ func RequestLogger(logger lib.ILogger) gin.HandlerFunc {
 		raw := c.Request.URL.RawQuery
 
 		start := time.Now()
-		logger.Debugf("[HTTP-REQ] %s %s",
+		logger.Infof("[HTTP-REQ] %s %s",
 			c.Request.Method,
 			path,
 		)
@@ -30,11 +30,13 @@ func RequestLogger(logger lib.ILogger) gin.HandlerFunc {
 		// Log details
 		status := c.Writer.Status()
 		latency := time.Since(start).Round(time.Millisecond)
-		logger.Debugf("[HTTP-RES] %s %s [%d] %v",
+		requestID, _ := c.Get("request_id")
+		logger.Infof("[HTTP-RES] %s %s [%d] %v request_id=%v",
 			c.Request.Method,
 			path,
 			status,
 			latency,
+			requestID,
 		)
 	}
 }

--- a/proxy-router/internal/handlers/tcphandlers/tcp.go
+++ b/proxy-router/internal/handlers/tcphandlers/tcp.go
@@ -43,6 +43,8 @@ func NewTCPHandler(
 			return
 		}
 
+		sourceLog = sourceLog.With("request_id", msg.ID)
+
 		err = morRpcHandler.Handle(ctx, *msg, sourceLog, func(resp *morrpc.RpcResponse) error {
 			sourceLog.Debugf("sending TCP response for method: %s", msg.Method)
 			_, err := sendMsg(conn, resp)

--- a/proxy-router/internal/handlers/tcphandlers/tcp.go
+++ b/proxy-router/internal/handlers/tcphandlers/tcp.go
@@ -46,7 +46,7 @@ func NewTCPHandler(
 		sourceLog = sourceLog.With("request_id", msg.ID)
 
 		err = morRpcHandler.Handle(ctx, *msg, sourceLog, func(resp *morrpc.RpcResponse) error {
-			sourceLog.Debugf("sending TCP response for method: %s", msg.Method)
+			sourceLog.Infof("sending TCP response for method: %s", msg.Method)
 			_, err := sendMsg(conn, resp)
 			if err != nil {
 				sourceLog.Errorf("Error sending message: %s", err)

--- a/proxy-router/internal/lib/context.go
+++ b/proxy-router/internal/lib/context.go
@@ -1,6 +1,17 @@
 package lib
 
-import "context"
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// GenerateRequestID returns a random 8-character hex string for use as a request ID.
+func GenerateRequestID() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
 
 type contextKey string
 

--- a/proxy-router/internal/lib/context.go
+++ b/proxy-router/internal/lib/context.go
@@ -1,0 +1,27 @@
+package lib
+
+import "context"
+
+type contextKey string
+
+const requestIDKey contextKey = "request_id"
+
+// Plain string key so gin.Context.Value() finds it via gin's Get() path
+const requestIDStringKey = "request_id"
+
+func ContextWithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDKey, requestID)
+}
+
+func RequestIDFromContext(ctx context.Context) string {
+	// Try plain string key first — works with gin.Context which routes
+	// string keys through its internal map (Set/Get)
+	if v, ok := ctx.Value(requestIDStringKey).(string); ok {
+		return v
+	}
+	// Fall back to typed key — works with standard context.WithValue
+	if v, ok := ctx.Value(requestIDKey).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -195,7 +195,7 @@ func (c *ProxyController) Prompt(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))
@@ -1381,7 +1381,7 @@ func (c *ProxyController) AudioTranscription(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))
@@ -1562,7 +1562,7 @@ func (c *ProxyController) AudioSpeech(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))
@@ -1699,7 +1699,7 @@ func (c *ProxyController) Embeddings(ctx *gin.Context) {
 
 	requestID := head.RequestID
 	if requestID == "" {
-		requestID = "1"
+		requestID = lib.GenerateRequestID()
 	}
 	ctx.Set("request_id", requestID)
 	ctx.Request = ctx.Request.WithContext(lib.ContextWithRequestID(ctx.Request.Context(), requestID))

--- a/proxy-router/internal/proxyapi/controller_morrpc.go
+++ b/proxy-router/internal/proxyapi/controller_morrpc.go
@@ -50,6 +50,7 @@ func NewMORRPCController(service *ProxyReceiver, validator *validator.Validate, 
 }
 
 func (s *MORRPCController) Handle(ctx context.Context, msg m.RPCMessage, sourceLog lib.ILogger, sendResponse SendResponse) error {
+	sourceLog = sourceLog.With("request_id", msg.ID)
 	sourceLog.Debugf("received TCP message with method %s", msg.Method)
 	switch msg.Method {
 	case "network.ping":
@@ -140,6 +141,7 @@ func (s *MORRPCController) sessionPrompt(ctx context.Context, msg m.RPCMessage, 
 		return lib.WrapError(ErrValidation, err)
 	}
 
+	sourceLog = sourceLog.With("session_id", req.SessionID.Hex())
 	sourceLog.Debugf("received prompt from session %s, timestamp: %d", req.SessionID, req.Timestamp)
 
 	// Validate session exists and is not expired

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -331,16 +331,16 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 
 	// Process request with appropriate adapter method
 	if audioTranscriptionReq != nil {
-		sourceLog.Debugf("Processing audio transcription request")
+		sourceLog.Infof("Processing audio transcription request")
 		err = adapter.AudioTranscription(ctx, audioTranscriptionReq, cb)
 	} else if audioSpeechReq != nil {
-		sourceLog.Debugf("Processing audio speech request")
+		sourceLog.Infof("Processing audio speech request")
 		err = adapter.AudioSpeech(ctx, audioSpeechReq, cb)
 	} else if embeddingsReq != nil {
-		sourceLog.Debugf("Processing embeddings request")
+		sourceLog.Infof("Processing embeddings request")
 		err = adapter.Embeddings(ctx, embeddingsReq, cb)
 	} else {
-		sourceLog.Debugf("Processing chat completion request")
+		sourceLog.Infof("Processing chat completion request")
 		err = adapter.Prompt(ctx, chatReq, cb)
 	}
 
@@ -355,7 +355,7 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 }
 
 func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID string, req *m.SessionReq, log lib.ILogger) (*msg.RpcResponse, error) {
-	log.Debugf("Received session request from %s, timestamp: %s", req.User, req.Timestamp)
+	log.Infof("Received session request from %s, timestamp: %s", req.User, req.Timestamp)
 
 	bid, err := s.service.GetBidByID(ctx, req.BidID)
 	if err != nil {
@@ -406,7 +406,7 @@ func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID 
 }
 
 func (s *ProxyReceiver) SessionReport(ctx context.Context, msgID string, reqID string, session *storages.Session, sourceLog lib.ILogger) (*msg.RpcResponse, error) {
-	sourceLog.Debugf("received session report request for %s", session.Id)
+	sourceLog.Infof("received session report request for %s", session.Id)
 
 	tps := 0
 	ttft := 0
@@ -444,7 +444,7 @@ func (s *ProxyReceiver) SessionReport(ctx context.Context, msgID string, reqID s
 }
 
 func (s *ProxyReceiver) CallAgentTool(ctx context.Context, msgID string, reqID string, userPubKey string, req *m.CallAgentToolReq, sourceLog lib.ILogger) (*msg.RpcResponse, error) {
-	sourceLog.Debugf("received call agent tool request for %s", req.SessionID)
+	sourceLog.Infof("received call agent tool request for %s", req.SessionID)
 
 	var input map[string]interface{}
 
@@ -496,7 +496,7 @@ func (s *ProxyReceiver) CallAgentTool(ctx context.Context, msgID string, reqID s
 }
 
 func (s *ProxyReceiver) GetAgentTools(ctx context.Context, msgID string, reqID string, userPubKey string, req *m.GetAgentToolsReq, sourceLog lib.ILogger) (*msg.RpcResponse, error) {
-	sourceLog.Debugf("received get agent tools request for %s", req.SessionID)
+	sourceLog.Infof("received get agent tools request for %s", req.SessionID)
 
 	session, err := s.sessionRepo.GetSession(ctx, req.SessionID)
 	if err != nil {

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -265,6 +265,8 @@ func (s *ProxyReceiver) recordActivity(ctx context.Context, session *sessionrepo
 }
 
 func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, userPubKey string, payload []byte, sessionID common.Hash, sendResponse SendResponse, sourceLog lib.ILogger) (int, int, int, error) {
+	ctx = lib.ContextWithRequestID(ctx, requestID)
+
 	// Get session
 	session, err := s.sessionRepo.GetSession(ctx, sessionID)
 	if err != nil {

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -53,17 +53,17 @@ const (
 )
 
 type ProxyServiceSender struct {
-	chainID              *big.Int
-	privateKey           interfaces.PrKeyProvider
-	logStorage           *lib.Collection[*interfaces.LogStorage]
-	sessionStorage       *storages.SessionStorage
-	sessionRepo          *sessionrepo.SessionRepositoryCached
-	morRPC               *msgs.MORRPCMessage
-	sessionService       SessionService
-	sessionSema          *SessionSemaphore // Limits to 1 concurrent request per session
-	cnodePnodeTimeout         time.Duration // Per-attempt timeout waiting for PNode first response
-	cnodePnodeMaxRetries      int           // Max retries on read timeout from PNode (chat/embeddings)
-	cnodePnodeAudioMaxRetries int           // Max retries on read timeout from PNode (audio)
+	chainID                   *big.Int
+	privateKey                interfaces.PrKeyProvider
+	logStorage                *lib.Collection[*interfaces.LogStorage]
+	sessionStorage            *storages.SessionStorage
+	sessionRepo               *sessionrepo.SessionRepositoryCached
+	morRPC                    *msgs.MORRPCMessage
+	sessionService            SessionService
+	sessionSema               *SessionSemaphore // Limits to 1 concurrent request per session
+	cnodePnodeTimeout         time.Duration     // Per-attempt timeout waiting for PNode first response
+	cnodePnodeMaxRetries      int               // Max retries on read timeout from PNode (chat/embeddings)
+	cnodePnodeAudioMaxRetries int               // Max retries on read timeout from PNode (audio)
 	log                       lib.ILogger
 }
 
@@ -503,6 +503,8 @@ func (p *ProxyServiceSender) validateMsgSignatureAddr(result any, signature lib.
 
 // validateSession checks if a session is valid and returns session and provider information
 func (p *ProxyServiceSender) validateSession(ctx context.Context, sessionID common.Hash) (*sessionrepo.SessionModel, *storages.User, error) {
+	log := p.log.With("request_id", lib.RequestIDFromContext(ctx), "session_id", sessionID.Hex())
+
 	// Get session and verify it exists
 	session, err := p.sessionRepo.GetSession(ctx, sessionID)
 	if err != nil {
@@ -512,8 +514,8 @@ func (p *ProxyServiceSender) validateSession(ctx context.Context, sessionID comm
 	SESSION_EXPIRY_THRESHOLD := time.Second * 5
 	// Check if session is expired
 	if session.EndsAt().Int64()+int64(SESSION_EXPIRY_THRESHOLD) < time.Now().Unix() {
-		p.log.Debugf("Expired session object endsAt: %v", session.EndsAt().Int64())
-		p.log.Debugf("Now: %v", time.Now().Unix())
+		log.Debugf("Expired session object endsAt: %v", session.EndsAt().Int64())
+		log.Debugf("Now: %v", time.Now().Unix())
 		return nil, nil, ErrSessionExpired
 	}
 
@@ -530,21 +532,23 @@ func (p *ProxyServiceSender) validateSession(ctx context.Context, sessionID comm
 }
 
 // prepareRequest creates and prepares an RPC request for the provider
-func (p *ProxyServiceSender) prepareRequest(sessionID common.Hash, payload interface{}, providerPubKey string) (*msgs.RPCMessage, lib.HexString, error) {
-	// Get private key for encryption
+func (p *ProxyServiceSender) prepareRequest(ctx context.Context, sessionID common.Hash, payload interface{}, providerPubKey string) (*msgs.RPCMessage, lib.HexString, error) {
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = "1"
+	}
+
 	prKey, err := p.privateKey.GetPrivateKey()
 	if err != nil {
 		return nil, nil, ErrMissingPrKey
 	}
 
-	// Convert provider public key to hex string
 	pubKey, err := lib.StringToHexString(providerPubKey)
 	if err != nil {
 		return nil, nil, lib.WrapError(ErrCreateReq, err)
 	}
 
-	// Create RPC request
-	promptRequest, err := p.morRPC.SessionPromptRequest(sessionID, payload, pubKey, prKey, "1")
+	promptRequest, err := p.morRPC.SessionPromptRequest(sessionID, payload, pubKey, prKey, requestID)
 	if err != nil {
 		return nil, nil, lib.WrapError(ErrCreateReq, err)
 	}
@@ -601,7 +605,8 @@ func (p *ProxyServiceSender) updateSessionStats(ctx context.Context, session ses
 
 	err := p.sessionRepo.SaveSession(ctx, &session)
 	if err != nil {
-		p.log.Error(`failed to update session report stats`, err)
+		log := p.log.With("request_id", lib.RequestIDFromContext(ctx))
+		log.Error(`failed to update session report stats`, err)
 		return err
 	}
 
@@ -609,6 +614,9 @@ func (p *ProxyServiceSender) updateSessionStats(ctx context.Context, session ses
 }
 
 func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.Hash, prompt *gcs.OpenAICompletionRequestExtra, cb gcs.CompletionCallback) (interface{}, error) {
+	requestID := lib.RequestIDFromContext(ctx)
+	log := p.log.With("request_id", requestID, "session_id", sessionID.Hex())
+
 	// Validate session and get provider
 	session, provider, err := p.validateSession(ctx, sessionID)
 	if err != nil {
@@ -616,16 +624,15 @@ func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session
-	// This will block if another request is already being processed for this session
-	p.log.Debugf("acquiring session semaphore for session %s", sessionID.Hex())
+	log.Debugf("acquiring session semaphore for session %s", sessionID.Hex())
 	if err := p.sessionSema.Acquire(ctx, sessionID); err != nil {
 		return nil, fmt.Errorf("request cancelled while waiting in queue: %w", err)
 	}
 	defer p.sessionSema.Release(sessionID)
-	p.log.Debugf("acquired session semaphore for session %s", sessionID.Hex())
+	log.Debugf("acquired session semaphore for session %s", sessionID.Hex())
 
 	// Prepare request
-	promptRequest, pubKey, err := p.prepareRequest(sessionID, prompt, provider.PubKey)
+	promptRequest, pubKey, err := p.prepareRequest(ctx, sessionID, prompt, provider.PubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -655,8 +662,7 @@ func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.
 
 	// Update session statistics
 	if updateErr := p.updateSessionStats(ctx, *session, startTime, ttftMs, inputTokens, outputTokens); updateErr != nil {
-		// Log error but don't fail the request
-		p.log.Error("Failed to update session stats", updateErr)
+		log.Error("Failed to update session stats", updateErr)
 	}
 
 	return result, nil
@@ -671,6 +677,8 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 	requestType string,
 	promptTokens int,
 ) (interface{}, int, int, int, error) {
+	log := p.log.With("request_id", lib.RequestIDFromContext(ctx))
+
 	const TIMEOUT_TO_ESTABLISH_CONNECTION = time.Second * 3
 
 	timeoutPerAttempt := p.cnodePnodeTimeout
@@ -689,7 +697,7 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 	conn, err := dialer.Dial("tcp", url)
 	if err != nil {
 		err = lib.WrapError(ErrConnectProvider, err)
-		p.log.Warnf(err.Error())
+		log.Warnf(err.Error())
 		return nil, 0, 0, 0, err
 	}
 	defer conn.Close()
@@ -698,11 +706,11 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		err := tcpConn.SetKeepAlive(true)
 		if err != nil {
-			p.log.Errorf("Error setting keepalive: %s", err)
+			log.Errorf("Error setting keepalive: %s", err)
 		}
 		err = tcpConn.SetKeepAlivePeriod(10 * time.Second)
 		if err != nil {
-			p.log.Errorf("Error setting keepalive period: %s", err)
+			log.Errorf("Error setting keepalive period: %s", err)
 		}
 	}
 
@@ -750,17 +758,17 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 		err = d.Decode(&msg)
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				p.log.Warnf("Read operation timed out: %v", err)
-				p.log.Infof("Retry count: %d, max retries: %d", retryCount, maxRetries)
+				log.Warnf("Read operation timed out: %v", err)
+				log.Infof("Retry count: %d, max retries: %d", retryCount, maxRetries)
 				if retryCount < maxRetries {
 					alive, availErr := checkProviderAvailability(url)
 					if availErr != nil {
-						p.log.Warnf("Provider availability check failed: %v", availErr)
+						log.Warnf("Provider availability check failed: %v", availErr)
 						return nil, ttftMs, inputTokens, outputTokens, fmt.Errorf("provider availability check failed: %w", availErr)
 					}
 					if alive {
 						retryCount++
-						p.log.Infof("Provider is alive, retrying (%d/%d)...", retryCount, maxRetries)
+						log.Infof("Provider is alive, retrying (%d/%d)...", retryCount, maxRetries)
 						// Reset the read deadline
 						conn.SetReadDeadline(time.Now().Add(timeoutPerAttempt))
 						// Clear the error state by reading any remaining data
@@ -775,13 +783,13 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 					return nil, ttftMs, inputTokens, outputTokens, fmt.Errorf("read timed out after %d retries: %w", retryCount, err)
 				}
 			} else if err == io.EOF {
-				p.log.Debugf("Connection closed by provider")
+				log.Debugf("Connection closed by provider")
 				if !callbackCalled {
 					return nil, ttftMs, inputTokens, outputTokens, fmt.Errorf("provider closed connection without sending any data")
 				}
 				break
 			} else {
-				p.log.Warnf("Failed to decode response: %v", err)
+				log.Warnf("Failed to decode response: %v", err)
 				return nil, ttftMs, inputTokens, outputTokens, lib.WrapError(ErrInvalidResponse, err)
 			}
 		}
@@ -794,7 +802,7 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 			sigStr := sig.String()
 			if sig == nil || len(sig) == 0 || sigStr == "0x00" {
 				// Unencrypted error - return as plain error without callback
-				p.log.Warnf("Received unencrypted provider error: %s (code: %d)", msg.Error.Message, msg.Error.Code)
+				log.Warnf("Received unencrypted provider error: %s (code: %d)", msg.Error.Message, msg.Error.Code)
 				return nil, ttftMs, inputTokens, outputTokens, fmt.Errorf("provider error: %s", msg.Error.Message)
 			}
 
@@ -1135,6 +1143,9 @@ func checkProviderAvailability(url string) (bool, error) {
 
 // SendAudioTranscriptionStreamV2 sends audio transcription using streaming chunks to avoid memory issues with large files
 func (p *ProxyServiceSender) SendAudioTranscriptionV2(ctx context.Context, sessionID common.Hash, audioRequest *gcs.AudioTranscriptionRequest, cb gcs.CompletionCallback) (interface{}, error) {
+	requestID := lib.RequestIDFromContext(ctx)
+	log := p.log.With("request_id", requestID, "session_id", sessionID.Hex())
+
 	// Validate session and get provider
 	session, provider, err := p.validateSession(ctx, sessionID)
 	if err != nil {
@@ -1142,12 +1153,12 @@ func (p *ProxyServiceSender) SendAudioTranscriptionV2(ctx context.Context, sessi
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session
-	p.log.Debugf("acquiring session semaphore for session %s (audio transcription)", sessionID.Hex())
+	log.Debugf("acquiring session semaphore for session %s (audio transcription)", sessionID.Hex())
 	if err := p.sessionSema.Acquire(ctx, sessionID); err != nil {
 		return nil, fmt.Errorf("request cancelled while waiting in queue: %w", err)
 	}
 	defer p.sessionSema.Release(sessionID)
-	p.log.Debugf("acquired session semaphore for session %s (audio transcription)", sessionID.Hex())
+	log.Debugf("acquired session semaphore for session %s (audio transcription)", sessionID.Hex())
 
 	// Get private key for signing
 	prKey, err := p.privateKey.GetPrivateKey()
@@ -1192,13 +1203,13 @@ func (p *ProxyServiceSender) SendAudioTranscriptionV2(ctx context.Context, sessi
 		// Detect content type
 		contentType := detectAudioContentType(audioFilePath)
 
-		p.log.Debugf("Starting audio streaming for file %s, size: %d bytes, chunks: %d", audioFilePath, fileSize, totalChunks)
+		log.Debugf("Starting audio streaming for file %s, size: %d bytes, chunks: %d", audioFilePath, fileSize, totalChunks)
 
 		// Record start time for session stats
 		startTime = time.Now().Unix()
 
 		// Step 1: Start streaming session
-		err = p.sendStreamStart(provider, sessionID, streamID, totalChunks, fileSize, contentType, prKey)
+		err = p.sendStreamStart(ctx, provider, sessionID, streamID, totalChunks, fileSize, contentType, prKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start streaming session: %w", err)
 		}
@@ -1220,7 +1231,6 @@ func (p *ProxyServiceSender) SendAudioTranscriptionV2(ctx context.Context, sessi
 			return nil, lib.WrapError(ErrCreateReq, err)
 		}
 
-		requestID := "1"
 		audioRequest.Extra["type"] = json.RawMessage(`"audio_transcription"`)
 		message, err := p.morRPC.SessionPromptRequest(sessionID, audioRequest, pubKey, prKey, requestID)
 		if err != nil {
@@ -1239,16 +1249,18 @@ func (p *ProxyServiceSender) SendAudioTranscriptionV2(ctx context.Context, sessi
 
 	// Update session statistics
 	if updateErr := p.updateSessionStats(ctx, *session, startTime, ttftMs, inputTokens, outputTokens); updateErr != nil {
-		// Log error but don't fail the request
-		p.log.Error("Failed to update session stats", updateErr)
+		log.Error("Failed to update session stats", updateErr)
 	}
 
 	return result, nil
 }
 
 // sendStreamStart initiates the streaming session
-func (p *ProxyServiceSender) sendStreamStart(provider *storages.User, sessionID common.Hash, streamID string, totalChunks uint32, fileSize uint64, contentType string, prKey lib.HexString) error {
-	requestID := "1"
+func (p *ProxyServiceSender) sendStreamStart(ctx context.Context, provider *storages.User, sessionID common.Hash, streamID string, totalChunks uint32, fileSize uint64, contentType string, prKey lib.HexString) error {
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = "1"
+	}
 	message, err := p.morRPC.SessionPromptStreamStartRequest(sessionID, streamID, totalChunks, contentType, fileSize, prKey, requestID)
 	if err != nil {
 		return fmt.Errorf("failed to create stream start request: %w", err)
@@ -1277,7 +1289,7 @@ func (p *ProxyServiceSender) sendStreamStart(provider *storages.User, sessionID 
 		return fmt.Errorf("stream start failed: %s", response.Error.Message)
 	}
 
-	p.log.Debugf("Stream start successful for stream ID: %s", streamID)
+	p.log.With("request_id", requestID).Debugf("Stream start successful for stream ID: %s", streamID)
 	return nil
 }
 
@@ -1303,9 +1315,12 @@ func (p *ProxyServiceSender) sendStreamChunks(ctx context.Context, provider *sto
 		}
 
 		chunkData := buffer[:n]
-		requestID := "1"
+		chunkRequestID := lib.RequestIDFromContext(ctx)
+		if chunkRequestID == "" {
+			chunkRequestID = "1"
+		}
 
-		message, err := p.morRPC.SessionPromptStreamChunkRequest(sessionID, streamID, chunkIndex, chunkData, prKey, requestID)
+		message, err := p.morRPC.SessionPromptStreamChunkRequest(sessionID, streamID, chunkIndex, chunkData, prKey, chunkRequestID)
 		if err != nil {
 			return fmt.Errorf("failed to create chunk request for chunk %d: %w", chunkIndex, err)
 		}
@@ -1336,7 +1351,7 @@ func (p *ProxyServiceSender) sendStreamChunks(ctx context.Context, provider *sto
 			return fmt.Errorf("chunk %d failed: %s", chunkIndex, response.Error.Message)
 		}
 
-		p.log.Debugf("Successfully sent chunk %d/%d for stream %s", chunkIndex+1, totalChunks, streamID)
+		p.log.With("request_id", lib.RequestIDFromContext(ctx)).Debugf("Successfully sent chunk %d/%d for stream %s", chunkIndex+1, totalChunks, streamID)
 
 		// time.Sleep(2000 * time.Millisecond)
 		chunkIndex++
@@ -1359,7 +1374,10 @@ func (p *ProxyServiceSender) sendStreamEnd(ctx context.Context, provider *storag
 		return nil, 0, 0, 0, lib.WrapError(ErrCreateReq, err)
 	}
 
-	requestID := "1"
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = "1"
+	}
 	message, err := p.morRPC.SessionPromptStreamEndRequest(sessionID, streamID, string(audioParamsJSON), prKey, requestID)
 	if err != nil {
 		return nil, 0, 0, 0, fmt.Errorf("failed to create stream end request: %w", err)
@@ -1371,7 +1389,7 @@ func (p *ProxyServiceSender) sendStreamEnd(ctx context.Context, provider *storag
 		return nil, 0, 0, 0, fmt.Errorf("failed to process stream end request: %w", err)
 	}
 
-	p.log.Debugf("Successfully completed streaming session %s with TTFT: %dms, inputTokens: %d, outputTokens: %d", streamID, ttftMs, inputTokens, outputTokens)
+	p.log.With("request_id", requestID).Debugf("Successfully completed streaming session %s with TTFT: %dms, inputTokens: %d, outputTokens: %d", streamID, ttftMs, inputTokens, outputTokens)
 	return result, ttftMs, inputTokens, outputTokens, nil
 }
 
@@ -1403,6 +1421,12 @@ func detectAudioContentType(filePath string) string {
 
 // SendAudioSpeech sends audio speech generation request
 func (p *ProxyServiceSender) SendAudioSpeech(ctx context.Context, sessionID common.Hash, audioRequest *gcs.AudioSpeechRequest, cb gcs.CompletionCallback) (interface{}, error) {
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = "1"
+	}
+	log := p.log.With("request_id", requestID, "session_id", sessionID.Hex())
+
 	// Validate session and get provider
 	session, provider, err := p.validateSession(ctx, sessionID)
 	if err != nil {
@@ -1410,12 +1434,12 @@ func (p *ProxyServiceSender) SendAudioSpeech(ctx context.Context, sessionID comm
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session
-	p.log.Debugf("acquiring session semaphore for session %s (audio speech)", sessionID.Hex())
+	log.Debugf("acquiring session semaphore for session %s (audio speech)", sessionID.Hex())
 	if err := p.sessionSema.Acquire(ctx, sessionID); err != nil {
 		return nil, fmt.Errorf("request cancelled while waiting in queue: %w", err)
 	}
 	defer p.sessionSema.Release(sessionID)
-	p.log.Debugf("acquired session semaphore for session %s (audio speech)", sessionID.Hex())
+	log.Debugf("acquired session semaphore for session %s (audio speech)", sessionID.Hex())
 
 	// Get private key for signing
 	prKey, err := p.privateKey.GetPrivateKey()
@@ -1428,7 +1452,6 @@ func (p *ProxyServiceSender) SendAudioSpeech(ctx context.Context, sessionID comm
 		return nil, lib.WrapError(ErrCreateReq, err)
 	}
 
-	requestID := "1"
 	audioRequest.Extra["type"] = json.RawMessage(`"audio_speech"`)
 	message, err := p.morRPC.SessionPromptRequest(sessionID, audioRequest, pubKey, prKey, requestID)
 	if err != nil {
@@ -1459,16 +1482,21 @@ func (p *ProxyServiceSender) SendAudioSpeech(ctx context.Context, sessionID comm
 
 	// Update session statistics
 	if updateErr := p.updateSessionStats(ctx, *session, startTime, ttftMs, inputTokens, outputTokens); updateErr != nil {
-		// Log error but don't fail the request
-		p.log.Error("Failed to update session stats", updateErr)
+		log.Error("Failed to update session stats", updateErr)
 	}
 
-	p.log.Debugf("Successfully completed audio speech generation for session %s with TTFT: %dms, inputTokens: %d, outputTokens: %d", sessionID.Hex(), ttftMs, inputTokens, outputTokens)
+	log.Debugf("Successfully completed audio speech generation for session %s with TTFT: %dms, inputTokens: %d, outputTokens: %d", sessionID.Hex(), ttftMs, inputTokens, outputTokens)
 	return result, nil
 }
 
 // SendEmbeddings sends an embeddings generation request
 func (p *ProxyServiceSender) SendEmbeddings(ctx context.Context, sessionID common.Hash, embedRequest *gcs.EmbeddingsRequest, cb gcs.CompletionCallback) (interface{}, error) {
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = "1"
+	}
+	log := p.log.With("request_id", requestID, "session_id", sessionID.Hex())
+
 	// Validate session and get provider
 	session, provider, err := p.validateSession(ctx, sessionID)
 	if err != nil {
@@ -1476,12 +1504,12 @@ func (p *ProxyServiceSender) SendEmbeddings(ctx context.Context, sessionID commo
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session
-	p.log.Debugf("acquiring session semaphore for session %s (embeddings)", sessionID.Hex())
+	log.Debugf("acquiring session semaphore for session %s (embeddings)", sessionID.Hex())
 	if err := p.sessionSema.Acquire(ctx, sessionID); err != nil {
 		return nil, fmt.Errorf("request cancelled while waiting in queue: %w", err)
 	}
 	defer p.sessionSema.Release(sessionID)
-	p.log.Debugf("acquired session semaphore for session %s (embeddings)", sessionID.Hex())
+	log.Debugf("acquired session semaphore for session %s (embeddings)", sessionID.Hex())
 
 	// Get private key for signing
 	prKey, err := p.privateKey.GetPrivateKey()
@@ -1500,7 +1528,6 @@ func (p *ProxyServiceSender) SendEmbeddings(ctx context.Context, sessionID commo
 		return nil, lib.WrapError(ErrCreateReq, err)
 	}
 
-	requestID := "1"
 	message, err := p.morRPC.SessionPromptRequest(sessionID, embedRequest, pubKey, prKey, requestID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create embeddings request: %w", err)
@@ -1527,9 +1554,9 @@ func (p *ProxyServiceSender) SendEmbeddings(ctx context.Context, sessionID commo
 	}
 
 	if updateErr := p.updateSessionStats(ctx, *session, startTime, ttftMs, inputTokens, outputTokens); updateErr != nil {
-		p.log.Error("Failed to update session stats", updateErr)
+		log.Error("Failed to update session stats", updateErr)
 	}
 
-	p.log.Debugf("Successfully completed embeddings generation for session %s with TTFT: %dms, inputTokens: %d, outputTokens: %d", sessionID.Hex(), ttftMs, inputTokens, outputTokens)
+	log.Debugf("Successfully completed embeddings generation for session %s with TTFT: %dms, inputTokens: %d, outputTokens: %d", sessionID.Hex(), ttftMs, inputTokens, outputTokens)
 	return result, nil
 }

--- a/proxy-router/internal/proxyapi/requests.go
+++ b/proxy-router/internal/proxyapi/requests.go
@@ -31,9 +31,10 @@ type PromptReq struct {
 }
 
 type PromptHead struct {
-	SessionID lib.Hash `header:"session_id" validate:"hex32"`
-	ModelID   lib.Hash `header:"model_id"   validate:"hex32"`
-	ChatID    lib.Hash `header:"chat_id"    validate:"hex32"`
+	SessionID lib.Hash `header:"session_id"   validate:"hex32"`
+	ModelID   lib.Hash `header:"model_id"     validate:"hex32"`
+	ChatID    lib.Hash `header:"chat_id"      validate:"hex32"`
+	RequestID string   `header:"x-request-id"`
 }
 
 type AgentPromptHead struct {


### PR DESCRIPTION
- **Fix: session creation approval overflow** — corrects an integer overflow that could cause `InitiateSession` to fail intermittently during session open, contributing to "no provider accepting session" errors under load.
- **End-to-end `request_id` tracing** — every chat completion request now carries a consistent, anonymous `request_id` propagated from API Gateway through the C-Node and P-Node, making cross-service error correlation and debugging significantly easier.
