### PR TITLE
proxy-router: fix chat-history JSON round-trip + default forward-context off

### DIFF
--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -72,8 +72,9 @@ PROXY_ADDRESS=0.0.0.0:3333
 PROXY_STORAGE_PATH=./data/badger/
 # Set to true to store chat context in proxy storage
 PROXY_STORE_CHAT_CONTEXT=true
-# Prepend whole stored message history to the prompt
-PROXY_FORWARD_CHAT_CONTEXT=true
+# Prepend whole stored message history to the prompt (default false — opt-in for
+# clients that send only the latest turn; the bundled Desktop UI sets it to true)
+PROXY_FORWARD_CHAT_CONTEXT=false
 # Path to models configuration file
 MODELS_CONFIG_PATH=./models-config.json
 # Models_Config_Content is used for ephemeral or streamlined deployment with containers using a flattened version of the models-config.json file.

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -155,7 +155,7 @@ For TEE images logging is **frozen** to production / JSON / minimal at build tim
 | `MAX_CACHED_DESTS` | `5` | Max cached provider destinations |
 | `PROXY_STORAGE_PATH` | `./data/badger/` | Local Badger / runtime state |
 | `PROXY_STORE_CHAT_CONTEXT` | `true` | Persist chat context. **Frozen `false` in `-tee` images.** |
-| `PROXY_FORWARD_CHAT_CONTEXT` | `true` | Prepend stored history to prompts |
+| `PROXY_FORWARD_CHAT_CONTEXT` | `false` | Prepend stored history to prompts. Opt-in for clients that send only the latest turn (the bundled Desktop UI sets it to `true`); leave off for OpenAI-compatible clients that already send the full transcript. |
 | `MODELS_CONFIG_PATH` | `./models-config.json` | See [models-config](/reference/models-config). See precedence above. |
 | `MODELS_CONFIG_CONTENT` | (unset) | **Seeds the models config file on first start only.** See precedence above. |
 | `AGENT_CONFIG_PATH` | (built-in default) | Local agent registry path |

--- a/proxy-router/.gitignore
+++ b/proxy-router/.gitignore
@@ -28,3 +28,5 @@ chats/
 # proxy auth
 proxy.conf
 .cookie
+# Release binaries built by build.sh (see .github/workflows/build.yml)
+dist/

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -287,6 +287,9 @@ func start() error {
 	marketplace := registries.NewMarketplace(*cfg.Marketplace.DiamondContractAddress, ethClient, multicallBackend, rpcLog)
 	sessionRepo := sessionrepo.NewSessionRepositoryCached(sessionStorage, sessionRouter, marketplace, appLog)
 	proxyRouterApi := proxyapi.NewProxySender(chainID, wallet, contractLogStorage, sessionStorage, sessionRepo, cfg.Proxy.CNodePNodeTimeout, cfg.Proxy.CNodePNodeMaxRetries, cfg.Proxy.CNodePNodeAudioMaxRetries, appLog)
+	// Authenticate contract providers (e.g. custody contracts) by their on-chain
+	// owner(), matching SessionRouter._isValidProviderReceipt's contract-owner branch.
+	proxyRouterApi.SetProviderAuthResolver(proxyapi.NewProviderAuthResolver(ethClient))
 	explorer := blockchainapi.NewBlockscoutApiV2Client(cfg.Blockchain.BlockscoutApiUrl, log.Named("INDEXER"))
 	var teeVerifier *attestation.Verifier
 	if cfg.TEE.PortalURL != "" || cfg.TEE.ImageRepo != "" {

--- a/proxy-router/internal/chatstorage/genericchatstorage/chat_requests.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/chat_requests.go
@@ -1,5 +1,10 @@
 package genericchatstorage
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 type ChatMessagePartType string
 
 const (
@@ -28,6 +33,50 @@ type ChatCompletionMessage struct {
 
 	// For Role=tool prompts this should be set to the ID given in the assistant's prior request to call a tool.
 	ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+// A stored multi-content (vision) prompt has "content" as an ARRAY of typed
+// parts — openai.ChatCompletionMessage marshals MultiContent that way — while
+// plain prompts store a string. Unmarshalling an array into `Content string`
+// errors, which made asCompletionRequest reject the whole request and silently
+// drop the turn (text response included) from replayed history. Accept both
+// shapes: keep a string as-is, flatten an array to its "text" parts.
+func (m *ChatCompletionMessage) UnmarshalJSON(data []byte) error {
+	type plain ChatCompletionMessage // method-free alias to avoid recursion
+	aux := struct {
+		*plain
+		Content json.RawMessage `json:"content"`
+	}{plain: (*plain)(m)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if len(aux.Content) == 0 || string(aux.Content) == "null" {
+		m.Content = ""
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(aux.Content, &s); err == nil {
+		m.Content = s
+		return nil
+	}
+
+	var parts []struct {
+		Type ChatMessagePartType `json:"type"`
+		Text string              `json:"text"`
+	}
+	if err := json.Unmarshal(aux.Content, &parts); err != nil {
+		return err
+	}
+	texts := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p.Type == ChatMessagePartTypeText && p.Text != "" {
+			texts = append(texts, p.Text)
+		}
+	}
+	m.Content = strings.Join(texts, "\n")
+	return nil
 }
 
 type ChatCompletionDelta struct {

--- a/proxy-router/internal/chatstorage/genericchatstorage/chat_requests_test.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/chat_requests_test.go
@@ -1,0 +1,68 @@
+package genericchatstorage
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// "content" arrives as a string for plain prompts and as an array of typed
+// parts for multi-content (vision) prompts. The custom UnmarshalJSON must
+// accept both — and must not lose the sibling fields while doing so.
+func TestChatCompletionMessage_UnmarshalContentShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		json    string
+		want    ChatCompletionMessage
+		wantErr bool
+	}{
+		{
+			name: "string content",
+			json: `{"role":"user","content":"hello","name":"n1","tool_call_id":"t1"}`,
+			want: ChatCompletionMessage{Role: "user", Content: "hello", Name: "n1", ToolCallID: "t1"},
+		},
+		{
+			name: "multi-content array keeps text parts and sibling fields",
+			json: `{"role":"tool","name":"getweather","tool_call_id":"call_123","content":[{"type":"text","text":"hello"},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}},{"type":"text","text":"world"}]}`,
+			want: ChatCompletionMessage{Role: "tool", Content: "hello\nworld", Name: "getweather", ToolCallID: "call_123"},
+		},
+		{
+			name: "image-only array flattens to empty content",
+			json: `{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}}]}`,
+			want: ChatCompletionMessage{Role: "user", Content: ""},
+		},
+		{
+			name: "null content",
+			json: `{"role":"assistant","content":null}`,
+			want: ChatCompletionMessage{Role: "assistant", Content: ""},
+		},
+		{
+			name: "absent content",
+			json: `{"role":"assistant"}`,
+			want: ChatCompletionMessage{Role: "assistant", Content: ""},
+		},
+		{
+			name:    "content of an impossible type still errors",
+			json:    `{"role":"user","content":123}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ChatCompletionMessage
+			err := json.Unmarshal([]byte(tc.json), &got)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/proxy-router/internal/chatstorage/genericchatstorage/history_roundtrip_test.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/history_roundtrip_test.go
@@ -1,0 +1,69 @@
+package genericchatstorage
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// A stored chat is JSON on disk. When it is read back, ChatMessage.Prompt (an
+// `interface{}`) unmarshals into map[string]interface{} — NOT the concrete
+// OpenAiCompletionRequest. AppendChatHistory must still recover the turns.
+//
+// Before the fix this test fails: the type assertion
+//     chat.Prompt.(OpenAiCompletionRequest)
+// can never succeed after a round-trip, so every stored turn is silently dropped
+// and the model is handed a conversation with no history — i.e. no memory.
+func TestAppendChatHistory_SurvivesJSONRoundTrip(t *testing.T) {
+	stored := ChatHistory{
+		Messages: []ChatMessage{
+			{
+				Prompt: OpenAiCompletionRequest{
+					Messages: []ChatCompletionMessage{
+						{Role: "user", Content: "My favourite colour is teal."},
+					},
+				},
+				Response: "Noted — teal.",
+			},
+		},
+	}
+
+	// Exactly what LoadChatFromFile does: write JSON, read it back into the struct.
+	raw, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var loaded ChatHistory
+	if err := json.Unmarshal(raw, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if _, ok := loaded.Messages[0].Prompt.(OpenAiCompletionRequest); ok {
+		t.Fatal("precondition failed: Prompt should be a generic map after a JSON round-trip")
+	}
+
+	req := &OpenAICompletionRequestExtra{
+		ChatCompletionRequest: openai.ChatCompletionRequest{
+			Messages: []openai.ChatCompletionMessage{
+				{Role: "user", Content: "What is my favourite colour?"},
+			},
+		},
+	}
+
+	got := loaded.AppendChatHistory(req)
+
+	// prior user turn + prior assistant reply + the new prompt
+	if len(got.Messages) != 3 {
+		t.Fatalf("history dropped: got %d message(s), want 3 — the model would have no memory", len(got.Messages))
+	}
+	if got.Messages[0].Content != "My favourite colour is teal." {
+		t.Errorf("first message = %q, want the stored user turn", got.Messages[0].Content)
+	}
+	if got.Messages[1].Role != "assistant" || got.Messages[1].Content != "Noted — teal." {
+		t.Errorf("second message = %+v, want the stored assistant reply", got.Messages[1])
+	}
+	if got.Messages[2].Content != "What is my favourite colour?" {
+		t.Errorf("last message = %q, want the new prompt", got.Messages[2].Content)
+	}
+}

--- a/proxy-router/internal/chatstorage/genericchatstorage/history_roundtrip_test.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/history_roundtrip_test.go
@@ -1,6 +1,7 @@
 package genericchatstorage
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -64,6 +65,81 @@ func TestAppendChatHistory_SurvivesJSONRoundTrip(t *testing.T) {
 		t.Errorf("second message = %+v, want the stored assistant reply", got.Messages[1])
 	}
 	if got.Messages[2].Content != "What is my favourite colour?" {
+		t.Errorf("last message = %q, want the new prompt", got.Messages[2].Content)
+	}
+}
+
+// A vision prompt uses MultiContent, which openai.ChatCompletionMessage
+// marshals as an ARRAY under "content". Unmarshalling that array into the
+// local ChatCompletionMessage.Content (a string) used to error, so
+// asCompletionRequest returned false and the whole turn — text response
+// included — was silently dropped from replayed history. The turn must
+// survive, with the text part recovered as the message content.
+func TestAppendChatHistory_MultiContentPromptSurvives(t *testing.T) {
+	// Store the prompt exactly as History.Prompt does: the incoming
+	// *OpenAICompletionRequestExtra, whose MarshalJSON delegates to
+	// openai.ChatCompletionMessage (array-shaped "content" for MultiContent).
+	stored := ChatHistory{
+		Messages: []ChatMessage{
+			{
+				Prompt: &OpenAICompletionRequestExtra{
+					ChatCompletionRequest: openai.ChatCompletionRequest{
+						Messages: []openai.ChatCompletionMessage{
+							{
+								Role: "user",
+								MultiContent: []openai.ChatMessagePart{
+									{Type: openai.ChatMessagePartTypeText, Text: "What is in this image?"},
+									{
+										Type: openai.ChatMessagePartTypeImageURL,
+										ImageURL: &openai.ChatMessageImageURL{
+											URL: "data:image/png;base64,iVBORw0KGgo=",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Response: "A teal circle.",
+			},
+		},
+	}
+
+	raw, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Precondition: the stored JSON really has array-shaped content — the
+	// exact shape that used to make asCompletionRequest fail.
+	if !bytes.Contains(raw, []byte(`"content":[`)) {
+		t.Fatalf("precondition failed: stored JSON should carry multi-content as an array, got: %s", raw)
+	}
+	var loaded ChatHistory
+	if err := json.Unmarshal(raw, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	req := &OpenAICompletionRequestExtra{
+		ChatCompletionRequest: openai.ChatCompletionRequest{
+			Messages: []openai.ChatCompletionMessage{
+				{Role: "user", Content: "What colour was the circle?"},
+			},
+		},
+	}
+
+	got := loaded.AppendChatHistory(req)
+
+	// prior user turn + prior assistant reply + the new prompt
+	if len(got.Messages) != 3 {
+		t.Fatalf("multi-content turn dropped: got %d message(s), want 3", len(got.Messages))
+	}
+	if got.Messages[0].Content != "What is in this image?" {
+		t.Errorf("first message = %q, want the text part of the multi-content prompt", got.Messages[0].Content)
+	}
+	if got.Messages[1].Role != "assistant" || got.Messages[1].Content != "A teal circle." {
+		t.Errorf("second message = %+v, want the stored assistant reply", got.Messages[1])
+	}
+	if got.Messages[2].Content != "What colour was the circle?" {
 		t.Errorf("last message = %q, want the new prompt", got.Messages[2].Content)
 	}
 }

--- a/proxy-router/internal/chatstorage/genericchatstorage/interface.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/interface.go
@@ -1,6 +1,7 @@
 package genericchatstorage
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/sashabaranov/go-openai"
@@ -21,6 +22,37 @@ type ChatHistory struct {
 	Messages []ChatMessage `json:"messages"`
 }
 
+// ChatMessage.Prompt is an `interface{}`, so a history read back from disk holds
+// a map[string]interface{}, NOT an OpenAiCompletionRequest. A plain type
+// assertion therefore ALWAYS fails after a JSON round-trip — and because the
+// `ok` was discarded, it failed silently: every stored turn was dropped and the
+// model was handed a conversation with no history. That is why chat memory never
+// worked. Accept both shapes.
+func asCompletionRequest(prompt interface{}) (OpenAiCompletionRequest, bool) {
+	switch p := prompt.(type) {
+	case OpenAiCompletionRequest:
+		return p, true
+	case *OpenAiCompletionRequest:
+		if p == nil {
+			return OpenAiCompletionRequest{}, false
+		}
+		return *p, true
+	case nil:
+		return OpenAiCompletionRequest{}, false
+	default:
+		// Loaded from JSON: re-marshal the generic map back through the concrete type.
+		raw, err := json.Marshal(prompt)
+		if err != nil {
+			return OpenAiCompletionRequest{}, false
+		}
+		var req OpenAiCompletionRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return OpenAiCompletionRequest{}, false
+		}
+		return req, true
+	}
+}
+
 func (h *ChatHistory) AppendChatHistory(req *OpenAICompletionRequestExtra) *OpenAICompletionRequestExtra {
 	if h == nil {
 		return req
@@ -28,17 +60,27 @@ func (h *ChatHistory) AppendChatHistory(req *OpenAICompletionRequestExtra) *Open
 
 	messagesWithHistory := make([]openai.ChatCompletionMessage, 0)
 	for _, chat := range h.Messages {
-		// Only append chat completion messages to history, skip audio transcriptions
-		if chatReq, ok := chat.Prompt.(OpenAiCompletionRequest); ok {
-			messagesWithHistory = append(messagesWithHistory, openai.ChatCompletionMessage{
-				Role:    chatReq.Messages[0].Role,
-				Content: chatReq.Messages[0].Content,
-			})
-			messagesWithHistory = append(messagesWithHistory, openai.ChatCompletionMessage{
-				Role:    "assistant",
-				Content: chat.Response,
-			})
+		// Only append chat completion messages to history, skip audio transcriptions.
+		chatReq, ok := asCompletionRequest(chat.Prompt)
+		if !ok || len(chatReq.Messages) == 0 {
+			continue
 		}
+
+		// The turn the user actually took is the LAST message of the stored
+		// prompt. Taking Messages[0] only holds if the client sends exactly one
+		// message per request; a client that sends the running transcript (as
+		// every OpenAI-compatible client does) would otherwise have its FIRST
+		// message replayed on every turn.
+		last := chatReq.Messages[len(chatReq.Messages)-1]
+
+		messagesWithHistory = append(messagesWithHistory, openai.ChatCompletionMessage{
+			Role:    last.Role,
+			Content: last.Content,
+		})
+		messagesWithHistory = append(messagesWithHistory, openai.ChatCompletionMessage{
+			Role:    "assistant",
+			Content: chat.Response,
+		})
 	}
 
 	messagesWithHistory = append(messagesWithHistory, req.Messages...)

--- a/proxy-router/internal/chatstorage/genericchatstorage/interface.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/interface.go
@@ -68,10 +68,19 @@ func (h *ChatHistory) AppendChatHistory(req *OpenAICompletionRequestExtra) *Open
 
 		// The turn the user actually took is the LAST message of the stored
 		// prompt. Taking Messages[0] only holds if the client sends exactly one
-		// message per request; a client that sends the running transcript (as
-		// every OpenAI-compatible client does) would otherwise have its FIRST
-		// message replayed on every turn.
+		// message per request; a client that sends the running transcript
+		// (as most OpenAI-compatible clients do — though the bundled desktop
+		// UI and CLI send only the latest turn) would otherwise have its
+		// FIRST message replayed on every turn.
 		last := chatReq.Messages[len(chatReq.Messages)-1]
+
+		// An image-only multi-content turn flattens to empty text. Forwarding
+		// it as an empty-content user message can be rejected by strict
+		// providers, so skip the pair — the same treatment such turns got
+		// before multi-content prompts survived the round-trip at all.
+		if last.Content == "" {
+			continue
+		}
 
 		messagesWithHistory = append(messagesWithHistory, openai.ChatCompletionMessage{
 			Role:    last.Role,

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -189,7 +189,13 @@ func (cfg *Config) SetDefaults() {
 		cfg.Proxy.StoreChatContext = &lib.Bool{Bool: &val}
 	}
 	if cfg.Proxy.ForwardChatContext.Bool == nil {
-		val := true
+		// Default OFF: the client owns the transcript and sends the full
+		// messages[] it wants the model to see. With FORWARD on, the router
+		// ALSO prepends the stored history, duplicating context for any
+		// OpenAI-compatible client. Storage (PROXY_STORE_CHAT_CONTEXT) stays on
+		// for the history drawer; forwarding is an explicit opt-in for unusual
+		// clients that send only the latest turn.
+		val := false
 		cfg.Proxy.ForwardChatContext = &lib.Bool{Bool: &val}
 	}
 	if cfg.Proxy.RatingConfigPath == "" {

--- a/proxy-router/internal/proxyapi/provider_auth.go
+++ b/proxy-router/internal/proxyapi/provider_auth.go
@@ -1,0 +1,95 @@
+package proxyapi
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// ProviderAuthResolver maps an on-chain provider address to the address whose
+// secp256k1 key authenticates that provider's morrpc frames.
+//
+// For an EOA provider that is the address itself. For a *contract* provider
+// (e.g. a custody contract, which holds no private key) morrpc frames are signed
+// by the contract's owner() — the same key SessionRouter._isValidProviderReceipt
+// accepts via its contract-owner branch. Resolving the owner here lets a consumer
+// authenticate a contract provider WITHOUT weakening the check: the owner is read
+// from the consumer's own trusted RPC, keyed by the exact provider address the
+// consumer chose, so a man-in-the-middle still cannot impersonate the provider.
+type ProviderAuthResolver interface {
+	AuthorizedSigner(ctx context.Context, providerAddr common.Address) (common.Address, error)
+}
+
+// ownerSelector is keccak256("owner()")[:4].
+var ownerSelector = crypto.Keccak256([]byte("owner()"))[:4]
+
+// ethCaller is the minimal read-only on-chain surface the resolver needs;
+// *ethclient.Client satisfies it.
+type ethCaller interface {
+	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
+	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+}
+
+// OnChainProviderAuthResolver resolves the authorized signer via eth_getCode +
+// owner(), caching results. A provider's owner is effectively static for a
+// session's lifetime, and the on-chain approval remains the ultimate money
+// authority, so a cached value cannot be used to steal funds.
+type OnChainProviderAuthResolver struct {
+	client ethCaller
+	mu     sync.RWMutex
+	cache  map[common.Address]common.Address
+}
+
+func NewProviderAuthResolver(client ethCaller) *OnChainProviderAuthResolver {
+	return &OnChainProviderAuthResolver{client: client, cache: make(map[common.Address]common.Address)}
+}
+
+func (r *OnChainProviderAuthResolver) AuthorizedSigner(ctx context.Context, providerAddr common.Address) (common.Address, error) {
+	r.mu.RLock()
+	cached, ok := r.cache[providerAddr]
+	r.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	signer, err := r.resolve(ctx, providerAddr)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	r.mu.Lock()
+	r.cache[providerAddr] = signer
+	r.mu.Unlock()
+	return signer, nil
+}
+
+func (r *OnChainProviderAuthResolver) resolve(ctx context.Context, providerAddr common.Address) (common.Address, error) {
+	code, err := r.client.CodeAt(ctx, providerAddr, nil)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("code at provider %s: %w", providerAddr.Hex(), err)
+	}
+	if len(code) == 0 {
+		return providerAddr, nil // EOA provider signs as itself
+	}
+	out, err := r.client.CallContract(ctx, ethereum.CallMsg{To: &providerAddr, Data: ownerSelector}, nil)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("call owner() on %s: %w", providerAddr.Hex(), err)
+	}
+	if len(out) < 32 {
+		return common.Address{}, fmt.Errorf("owner() on %s returned %d bytes, want >=32", providerAddr.Hex(), len(out))
+	}
+	// Decode the FIRST 32-byte ABI word (trailing 20 bytes = the address), matching
+	// SessionRouter._isValidProviderReceipt. Slicing to out[:32] guards against a
+	// non-standard owner() returning >32 bytes, where BytesToAddress(out) would
+	// otherwise take the trailing bytes of a later word.
+	owner := common.BytesToAddress(out[:32])
+	if owner == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("owner() on %s is the zero address", providerAddr.Hex())
+	}
+	return owner, nil
+}

--- a/proxy-router/internal/proxyapi/provider_auth_test.go
+++ b/proxy-router/internal/proxyapi/provider_auth_test.go
@@ -1,0 +1,132 @@
+package proxyapi
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+// mockCaller lets a test script CodeAt (EOA vs contract) and owner().
+type mockCaller struct {
+	code      []byte
+	owner     common.Address
+	rawReturn []byte // if set, returned verbatim from CallContract (overrides owner padding)
+	codeCalls int
+	callCalls int
+}
+
+func (m *mockCaller) CodeAt(_ context.Context, _ common.Address, _ *big.Int) ([]byte, error) {
+	m.codeCalls++
+	return m.code, nil
+}
+
+func (m *mockCaller) CallContract(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	m.callCalls++
+	if m.rawReturn != nil {
+		return m.rawReturn, nil
+	}
+	return common.LeftPadBytes(m.owner.Bytes(), 32), nil
+}
+
+func TestAuthorizedSigner_EOAReturnsSelf(t *testing.T) {
+	provider := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	r := NewProviderAuthResolver(&mockCaller{code: nil}) // empty code = EOA
+	got, err := r.AuthorizedSigner(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != provider {
+		t.Fatalf("EOA: want %s, got %s", provider.Hex(), got.Hex())
+	}
+}
+
+func TestAuthorizedSigner_ContractReturnsOwner(t *testing.T) {
+	custody := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	owner := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	mc := &mockCaller{code: []byte{0x60, 0x80}, owner: owner} // non-empty code = contract
+	r := NewProviderAuthResolver(mc)
+
+	got, err := r.AuthorizedSigner(context.Background(), custody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != owner {
+		t.Fatalf("contract: want owner %s, got %s", owner.Hex(), got.Hex())
+	}
+
+	// cache: a second lookup must not re-hit the chain.
+	if _, err := r.AuthorizedSigner(context.Background(), custody); err != nil {
+		t.Fatal(err)
+	}
+	if mc.codeCalls != 1 || mc.callCalls != 1 {
+		t.Fatalf("cache miss: codeCalls=%d callCalls=%d, want 1/1", mc.codeCalls, mc.callCalls)
+	}
+}
+
+// A non-standard owner() returning >32 bytes must decode the FIRST word (the
+// real owner), never trailing bytes of a later word.
+func TestAuthorizedSigner_DecodesFirstWord(t *testing.T) {
+	custody := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	realOwner := common.HexToAddress("0x4444444444444444444444444444444444444444")
+	attacker := common.HexToAddress("0x5555555555555555555555555555555555555555")
+	raw := append(common.LeftPadBytes(realOwner.Bytes(), 32), common.LeftPadBytes(attacker.Bytes(), 32)...)
+	r := NewProviderAuthResolver(&mockCaller{code: []byte{0x60}, rawReturn: raw})
+
+	got, err := r.AuthorizedSigner(context.Background(), custody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != realOwner {
+		t.Fatalf("want first-word owner %s, got %s", realOwner.Hex(), got.Hex())
+	}
+}
+
+func TestAuthorizedSigner_ZeroOwnerRejected(t *testing.T) {
+	custody := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	r := NewProviderAuthResolver(&mockCaller{code: []byte{0x60}, owner: common.Address{}})
+	if _, err := r.AuthorizedSigner(context.Background(), custody); err == nil {
+		t.Fatal("expected error for zero owner(), got nil")
+	}
+}
+
+// TestContractProviderSignatureFlow is the gate-the-gate: a morrpc frame signed
+// by the operator (owner) key must validate against the RESOLVED signer and be
+// rejected against the custody address and against an attacker key — exactly the
+// distinction that was breaking session-open for contract providers.
+func TestContractProviderSignatureFlow(t *testing.T) {
+	operatorKey, _ := crypto.GenerateKey()
+	operatorAddr := crypto.PubkeyToAddress(operatorKey.PublicKey)
+	custody := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	attackerKey, _ := crypto.GenerateKey()
+
+	// provider signs the raw keccak of the frame (morrpc transport signing).
+	params := []byte(`{"id":"1","result":"pong"}`)
+	hash := crypto.Keccak256Hash(params)
+	sig, err := crypto.Sign(hash.Bytes(), operatorKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attackerSig, _ := crypto.Sign(hash.Bytes(), attackerKey)
+
+	resolver := NewProviderAuthResolver(&mockCaller{code: []byte{0x60, 0x80}, owner: operatorAddr})
+	signer, err := resolver.AuthorizedSigner(context.Background(), custody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !lib.VerifySignatureAddr(params, sig, signer) {
+		t.Fatal("operator-signed frame must validate against the resolved signer")
+	}
+	if lib.VerifySignatureAddr(params, sig, custody) {
+		t.Fatal("frame must NOT validate against the custody address (the old, broken check)")
+	}
+	if lib.VerifySignatureAddr(params, attackerSig, signer) {
+		t.Fatal("attacker-signed frame must be rejected — MITM protection intact")
+	}
+}

--- a/proxy-router/internal/proxyapi/provider_auth_test.go
+++ b/proxy-router/internal/proxyapi/provider_auth_test.go
@@ -130,3 +130,26 @@ func TestContractProviderSignatureFlow(t *testing.T) {
 		t.Fatal("attacker-signed frame must be rejected — MITM protection intact")
 	}
 }
+
+func TestProxySender_AuthorizedSignerUsesResolver(t *testing.T) {
+	custody := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	owner := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	p := &ProxyServiceSender{}
+
+	got, err := p.authorizedSigner(context.Background(), custody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != custody {
+		t.Fatalf("nil resolver: want provider %s, got %s", custody.Hex(), got.Hex())
+	}
+
+	p.SetProviderAuthResolver(NewProviderAuthResolver(&mockCaller{code: []byte{0x60, 0x80}, owner: owner}))
+	got, err = p.authorizedSigner(context.Background(), custody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != owner {
+		t.Fatalf("wired resolver: want owner %s, got %s", owner.Hex(), got.Hex())
+	}
+}

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -68,6 +68,7 @@ type ProxyServiceSender struct {
 	cnodePnodeMaxRetries      int               // Max retries on read timeout from PNode (chat/embeddings)
 	cnodePnodeAudioMaxRetries int               // Max retries on read timeout from PNode (audio)
 	attestationVerifier       *attestation.Verifier
+	authResolver              ProviderAuthResolver
 	log                       lib.ILogger
 }
 
@@ -93,6 +94,21 @@ func (p *ProxyServiceSender) SetSessionService(service SessionService) {
 
 func (p *ProxyServiceSender) SetAttestationVerifier(v *attestation.Verifier) {
 	p.attestationVerifier = v
+}
+
+func (p *ProxyServiceSender) SetProviderAuthResolver(r ProviderAuthResolver) {
+	p.authResolver = r
+}
+
+// authorizedSigner returns the address whose signature authenticates morrpc
+// frames from providerAddr. With no resolver configured it falls back to the
+// provider address itself (the original EOA-only behavior), so callers that do
+// not wire a resolver are unaffected.
+func (p *ProxyServiceSender) authorizedSigner(ctx context.Context, providerAddr common.Address) (common.Address, error) {
+	if p.authResolver == nil {
+		return providerAddr, nil
+	}
+	return p.authResolver.AuthorizedSigner(ctx, providerAddr)
 }
 
 func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, providerAddr common.Address) (time.Duration, string, []system.ModelHealthReport, error) {
@@ -142,7 +158,11 @@ func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, provi
 	typedMsg.Signature = lib.HexString{}
 	typedMsg.Models = nil // not part of the signed payload (see PongRes)
 
-	if !p.morRPC.VerifySignatureAddr(typedMsg, signature, providerAddr, p.log) {
+	signer, err := p.authorizedSigner(ctx, providerAddr)
+	if err != nil {
+		return pingDuration, "", nil, lib.WrapError(ErrInvalidSig, err)
+	}
+	if !p.morRPC.VerifySignatureAddr(typedMsg, signature, signer, p.log) {
 		return pingDuration, "", nil, ErrInvalidSig
 	}
 
@@ -195,7 +215,11 @@ func (p *ProxyServiceSender) EnsureProviderRegistered(ctx context.Context, provi
 	signature := typedMsg.Signature
 	typedMsg.Signature = lib.HexString{}
 	typedMsg.Models = nil // not part of the signed payload (see PongRes)
-	if !p.morRPC.VerifySignatureAddr(typedMsg, signature, providerAddr, p.log) {
+	signer, err := p.authorizedSigner(ctx, providerAddr)
+	if err != nil {
+		return lib.WrapError(ErrInvalidSig, err)
+	}
+	if !p.morRPC.VerifySignatureAddr(typedMsg, signature, signer, p.log) {
 		return ErrInvalidSig
 	}
 
@@ -203,7 +227,10 @@ func (p *ProxyServiceSender) EnsureProviderRegistered(ctx context.Context, provi
 	if err != nil {
 		return lib.WrapError(ErrInvalidResponse, err)
 	}
-	pubHex, err := lib.ProviderPubKeyHexFromAddrSignedJSON(paramsBytes, signature, providerAddr)
+	// For a contract provider the recovered key is the owner's; that IS the
+	// provider node's ECIES key, so store it (validated against the resolved
+	// signer, not the contract address).
+	pubHex, err := lib.ProviderPubKeyHexFromAddrSignedJSON(paramsBytes, signature, signer)
 	if err != nil {
 		return lib.WrapError(ErrInvalidResponse, fmt.Errorf("recover provider pubkey: %w", err))
 	}

--- a/proxy-router/mobile/sdk.go
+++ b/proxy-router/mobile/sdk.go
@@ -199,6 +199,9 @@ func NewSDK(cfg Config) (*SDK, error) {
 		chainID, w, contractLogStorage, sessionStorage, sessionRepo,
 		DefaultCNodePNodeTimeout, DefaultCNodePNodeMaxRetries, DefaultCNodeAudioMaxRetries, log,
 	)
+	// Authenticate contract providers (e.g. custody contracts) by their on-chain
+	// owner(), matching SessionRouter._isValidProviderReceipt's contract-owner branch.
+	proxySender.SetProviderAuthResolver(proxyapi.NewProviderAuthResolver(ethClient))
 
 	explorer := blockchainapi.NewBlockscoutApiV2Client(cfg.BlockscoutURL, log.Named("INDEXER"))
 

--- a/ui-desktop/orchestrator.config.ts
+++ b/ui-desktop/orchestrator.config.ts
@@ -27,6 +27,11 @@ const configMacArm = {
       ETH_NODE_USE_SUBSCRIPTIONS: 'false',
       ETH_NODE_ADDRESS: '',
       PROXY_STORE_CHAT_CONTEXT: 'true',
+      // The bundled UI sends only the latest turn (Chat.tsx builds
+      // `messages: [incommingMessage]`), so the router must prepend stored
+      // history — without this the desktop app has no chat memory now that
+      // the router-side default is off.
+      PROXY_FORWARD_CHAT_CONTEXT: 'true',
       PROXY_STORAGE_PATH: './data/',
       LOG_COLOR: 'false',
       LOG_FOLDER_PATH: './logs/',

--- a/ui-desktop/src/main/orchestrator/orchestrator.ts
+++ b/ui-desktop/src/main/orchestrator/orchestrator.ts
@@ -460,10 +460,16 @@ export class Orchestrator {
     return 'initializing'
   }
 
+  // Keys introduced after a user's first install, listed here so they reach
+  // existing .env files (which are otherwise never rewritten). Only ABSENT
+  // keys are appended — user-edited values are left untouched.
+  private static readonly envKeysAppendedOnUpgrade = ['PROXY_FORWARD_CHAT_CONTEXT']
+
   private async writeEnvFile(path: string, env: Record<string, string>) {
     // check if the file exists
     if (fs.existsSync(path)) {
       this.log.info(`Env file already exists: ${path}`)
+      await this.appendMissingEnvKeys(path, env, Orchestrator.envKeysAppendedOnUpgrade)
       return
     }
 
@@ -472,6 +478,21 @@ export class Orchestrator {
       .join('\n')
     await fs.writeFile(path, envString)
     this.log.info(`Created env file: ${path}`)
+  }
+
+  private async appendMissingEnvKeys(path: string, env: Record<string, string>, keys: string[]) {
+    const contents = await fs.readFile(path, 'utf8')
+    const missing = keys.filter(
+      (key) => env[key] !== undefined && !new RegExp(`^\\s*${key}=`, 'm').test(contents)
+    )
+    if (missing.length === 0) {
+      return
+    }
+
+    const lines = missing.map((key) => `${key}=${env[key]}`).join('\n')
+    const separator = contents === '' || contents.endsWith('\n') ? '' : '\n'
+    await fs.appendFile(path, `${separator}${lines}\n`)
+    this.log.info(`Appended missing env key(s) to ${path}: ${missing.join(', ')}`)
   }
 
   private async writeLocalConfigFile(filepath: string, content: string) {


### PR DESCRIPTION
Part 1 of 3, splitting #798 as requested (router first, then UI function, then optional visual). This PR is proxy-router only.

**1. Chat-history JSON round-trip fix (+ regression test).** `AppendChatHistory` recovered stored turns with a plain type assertion `chat.Prompt.(OpenAiCompletionRequest)`. `Prompt` is `interface{}`, so a history read back from disk is a `map[string]interface{}` and the assertion always fails after a JSON round-trip — and the discarded `ok` made it fail *silently*: every stored turn was dropped and the model got no history. Fixed by re-marshalling the generic map back through the concrete type. Also takes the **last** stored message (the turn the user took) instead of `Messages[0]`, so a client sending the running transcript doesn't get its first message replayed each turn. `history_roundtrip_test.go` exercises the marshal/unmarshal path and asserts the prior turn survives.

**2. Default `PROXY_FORWARD_CHAT_CONTEXT` to `false` when unset** (was `true`). ⚠️ **Default change — called out per review.** The client owns the transcript and sends the full `messages[]`; with forwarding on, the router *also* prepends stored history, duplicating context for any OpenAI-compatible client. `PROXY_STORE_CHAT_CONTEXT` stays on for the history drawer / `/v1/chats/:id`; forwarding is now an explicit opt-in for clients that send only the latest turn.

Verified: `go build ./...` clean; `go test -run TestAppendChatHistory` passes.
