### PR TITLE
fix(tee): fetch SecretVM registries from secretvm-verify npm

### DIFF
--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -1,39 +1,44 @@
 # SecretVM artifact configuration for RTMR3 (Intel TDX) + SEV measurement (AMD SEV-SNP)
 # Update these when SCRT Labs publishes a new stable VM release.
 #
-# Source:    https://github.com/scrtlabs/secret-vm-build/releases
-# Algorithm: scrtlabs/reproduce-mr (Intel TDX RTMR3 = replayRTMR of sha256(compose) + sha256(rootfs))
-#            scrtlabs/secretvm-verify (AMD SEV-SNP launch digest via GCTX page-update chain)
+# Registries (MRTD/RTMR0-2 + SEV kernel/initrd/ovmf hashes):
+#   Published inside the secretvm-verify packages (GitHub repo removed):
+#     npm:  https://www.npmjs.com/package/secretvm-verify
+#     PyPI: https://pypi.org/project/secretvm-verify/
+#   CI/runtime fetch the bundled data/ files via jsDelivr CDN (pinned below).
+#
+# Rootfs ISO digests:
+#   SOURCE OF TRUTH for the release to pin is the SecretVM portal's Production
+#   "Artifacts version" (what new prod deploys actually run). Cross-check the
+#   pin against secretvm-verify's tdx.csv `rootfs_data` / sev.json `rootfs_hash`
+#   for that artifacts_ver. RTMR3 CI uses the pinned SHA-256 directly when the
+#   ISO download URL is unavailable (scrtlabs/secret-vm-build releases 404).
 #
 # IMPORTANT: Always use the "prod" rootfs variant — SecretVM runs "environment prod"
 # even for developer portal deployments. Using "dev" rootfs produces wrong measurements.
 #
-# SOURCE OF TRUTH for the release to pin is the SecretVM portal's Production
-# "Artifacts version" (what new prod deploys actually run), NOT GitHub's "Latest"
-# flag. These can diverge: the portal may expose a version that GitHub still marks
-# "Pre-release". As of 2026-07 the portal's Production artifacts version is v0.0.31
-# (GitHub lists v0.0.31 as a pre-release, and v0.0.28 as its "Latest"), so we pin
-# v0.0.31 to match what deploys actually boot. Rootfs SHA-256s below are the GitHub
-# release asset digests for the pinned tag.
+# As of 2026-07 the portal's Production artifacts version is v0.0.31.
 
 SECRETVM_RELEASE=v0.0.31
 SECRETVM_ROOTFS_VARIANT=rootfs-prod
 
+# Pin of the secretvm-verify package that carries tdx.csv / sev.json.
+# Bump together with SECRETVM_RELEASE when SCRT publishes a newer registry set.
+SECRETVM_VERIFY_NPM_VERSION=0.13.0
+SECRETVM_TDX_REGISTRY_URL=https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv
+SECRETVM_SEV_REGISTRY_URL=https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json
+SECRETVM_SEV_REGISTRY_VM_TYPE=prod
+
 # Intel TDX rootfs (non-GPU, prod — used for proxy-router P-Node deployments)
-# URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-tdx.iso
+# Optional download URL (legacy GitHub releases; currently 404). CI falls back to
+# SECRETVM_ROOTFS_TDX_SHA256 for RTMR3 when the URL is unreachable.
 SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.31/rootfs-prod-v0.0.31-tdx.iso
 SECRETVM_ROOTFS_TDX_SHA256=9d1ace112bc52c088c8c11b713c5f6e3021e0788278bb2fb47c571c7e728710c
 
 # AMD SEV-SNP rootfs (prod) — same compose, different platform binary
-# URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-sev.iso
+# Optional download URL (legacy). SEV measurement uses registry rootfs_hash + pin.
 SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.31/rootfs-prod-v0.0.31-sev.iso
 SECRETVM_ROOTFS_SEV_SHA256=4e11fcb840d9dffe2b33868314d33bac337f82a25f09b3ca990e21f3002a59d2
-
-# SEV artifact registry — kernel/initrd/ovmf hashes + ovmf_sections for measurement compute.
-# Pulled from scrtlabs/secretvm-verify; pipeline picks the entry whose `vm_type` and
-# `artifacts_ver` match SECRETVM_SEV_REGISTRY_VM_TYPE (prod) and SECRETVM_RELEASE.
-SECRETVM_SEV_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json
-SECRETVM_SEV_REGISTRY_VM_TYPE=prod
 
 # GPU variant (for co-located proxy+LLM deployments)
 # SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.31/rootfs-gpu-prod-v0.0.31-tdx.iso

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,60 +589,103 @@ jobs:
           echo "rootfs_tdx_sha256=$SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_OUTPUT
           echo "rootfs_sev_url=${SECRETVM_ROOTFS_SEV_URL:-}" >> $GITHUB_OUTPUT
           echo "rootfs_sev_sha256=${SECRETVM_ROOTFS_SEV_SHA256:-}" >> $GITHUB_OUTPUT
-          echo "sev_registry_url=${SECRETVM_SEV_REGISTRY_URL:-https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json}" >> $GITHUB_OUTPUT
+          echo "tdx_registry_url=${SECRETVM_TDX_REGISTRY_URL:-https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv}" >> $GITHUB_OUTPUT
+          echo "sev_registry_url=${SECRETVM_SEV_REGISTRY_URL:-https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json}" >> $GITHUB_OUTPUT
           echo "sev_registry_vm_type=${SECRETVM_SEV_REGISTRY_VM_TYPE:-prod}" >> $GITHUB_OUTPUT
+          echo "verify_npm_version=${SECRETVM_VERIFY_NPM_VERSION:-0.13.0}" >> $GITHUB_OUTPUT
 
           # legacy aliases retained so older steps continue to compile
           echo "rootfs_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
           echo "rootfs_sha256=$SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_OUTPUT
 
-      - name: Cache SecretVM rootfs
+      - name: Cache SecretVM artifacts
         id: cache-rootfs
         uses: actions/cache@v5
         with:
           path: /tmp/secretvm-artifacts
-          key: secretvm-${{ steps.secretvm-config.outputs.release }}-${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx-sev
+          key: secretvm-${{ steps.secretvm-config.outputs.release }}-${{ steps.secretvm-config.outputs.rootfs_variant }}-reg-${{ steps.secretvm-config.outputs.verify_npm_version }}
 
-      - name: Download SecretVM rootfs (TDX + SEV)
-        if: steps.cache-rootfs.outputs.cache-hit != 'true'
+      - name: Fetch SecretVM registries + optional rootfs
+        id: secretvm-artifacts
         run: |
           mkdir -p /tmp/secretvm-artifacts
+          set -euo pipefail
 
-          echo "⬇️  Downloading SecretVM TDX rootfs (${{ steps.secretvm-config.outputs.release }})..."
-          TDX_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx.iso"
-          curl -L --retry 3 --retry-delay 5 -o "$TDX_FILE" \
-            "${{ steps.secretvm-config.outputs.rootfs_tdx_url }}"
+          TDX_REG_URL="${{ steps.secretvm-config.outputs.tdx_registry_url }}"
+          SEV_REG_URL="${{ steps.secretvm-config.outputs.sev_registry_url }}"
+          TDX_REG_FILE="/tmp/secretvm-artifacts/tdx.csv"
+          SEV_REG_FILE="/tmp/secretvm-artifacts/sev.json"
 
-          TDX_ACTUAL_SHA=$(sha256sum "$TDX_FILE" | cut -d' ' -f1)
+          echo "⬇️  Fetching TDX registry from $TDX_REG_URL..."
+          curl -fsSL --retry 3 --retry-delay 5 -o "$TDX_REG_FILE" "$TDX_REG_URL"
+          echo "⬇️  Fetching SEV registry from $SEV_REG_URL..."
+          curl -fsSL --retry 3 --retry-delay 5 -o "$SEV_REG_FILE" "$SEV_REG_URL"
+
           TDX_EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_tdx_sha256 }}"
-          if [ -n "$TDX_EXPECTED_SHA" ]; then
-            echo "$TDX_EXPECTED_SHA  $TDX_FILE" | sha256sum -c -
-            echo "✅ SecretVM TDX rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️  No expected SHA256 configured — TDX rootfs hash: \`$TDX_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
-            echo "   PIN THIS in .github/tee/secretvm.env as SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "   TDX rootfs sha256: \`$TDX_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+          SEV_EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_sev_sha256 }}"
+          RELEASE="${{ steps.secretvm-config.outputs.release }}"
+          export TDX_EXPECTED_SHA SEV_EXPECTED_SHA RELEASE
 
-          if [ -n "${{ steps.secretvm-config.outputs.rootfs_sev_url }}" ]; then
-            echo "⬇️  Downloading SecretVM SEV rootfs (${{ steps.secretvm-config.outputs.release }})..."
-            SEV_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-sev.iso"
-            curl -L --retry 3 --retry-delay 5 -o "$SEV_FILE" \
-              "${{ steps.secretvm-config.outputs.rootfs_sev_url }}"
+          # Cross-check pins against secretvm-verify registries (npm/PyPI data/).
+          python3 - <<'PY'
+          import csv, json, os, sys
+          tdx_pin = os.environ["TDX_EXPECTED_SHA"].lower().removeprefix("0x")
+          sev_pin = os.environ["SEV_EXPECTED_SHA"].lower().removeprefix("0x")
+          release = os.environ["RELEASE"]
+          with open("/tmp/secretvm-artifacts/tdx.csv", newline="") as f:
+              rows = list(csv.DictReader(f))
+          tdx_ok = any(
+              r.get("artifacts_ver") == release
+              and r.get("vm_type") == "prod"
+              and (r.get("rootfs_data") or "").lower().removeprefix("0x") == tdx_pin
+              for r in rows
+          )
+          if not tdx_ok:
+              print(f"ERROR: TDX pin {tdx_pin} not found in tdx.csv for prod/{release}", file=sys.stderr)
+              sys.exit(1)
+          sev = json.load(open("/tmp/secretvm-artifacts/sev.json"))
+          sev_ok = any(
+              e.get("artifacts_ver") == release
+              and e.get("vm_type") == "prod"
+              and (e.get("rootfs_hash") or "").lower().removeprefix("0x") == sev_pin
+              for e in sev
+          )
+          if not sev_ok:
+              print(f"ERROR: SEV pin {sev_pin} not found in sev.json for prod/{release}", file=sys.stderr)
+              sys.exit(1)
+          print(f"✅ Pins match secretvm-verify registries for prod/{release}")
+          PY
 
-            SEV_ACTUAL_SHA=$(sha256sum "$SEV_FILE" | cut -d' ' -f1)
-            SEV_EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_sev_sha256 }}"
-            if [ -n "$SEV_EXPECTED_SHA" ]; then
-              echo "$SEV_EXPECTED_SHA  $SEV_FILE" | sha256sum -c -
-              echo "✅ SecretVM SEV rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
+          # Optional ISO download (legacy GitHub releases). Prefer pin when 404.
+          TDX_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx.iso"
+          ROOTFS_MODE="pin"
+          if curl -fsSL --retry 2 --retry-delay 3 -o "$TDX_FILE" \
+              "${{ steps.secretvm-config.outputs.rootfs_tdx_url }}"; then
+            ACTUAL=$(sha256sum "$TDX_FILE" | cut -d' ' -f1)
+            if [ "$ACTUAL" = "$TDX_EXPECTED_SHA" ]; then
+              ROOTFS_MODE="iso"
+              echo "✅ TDX rootfs ISO downloaded and matches pin" >> $GITHUB_STEP_SUMMARY
             else
-              echo "⚠️  No expected SHA256 configured — SEV rootfs hash: \`$SEV_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
-              echo "   PIN THIS in .github/tee/secretvm.env as SECRETVM_ROOTFS_SEV_SHA256" >> $GITHUB_STEP_SUMMARY
+              echo "⚠️  TDX ISO sha mismatch (got $ACTUAL); using pin for RTMR3" >> $GITHUB_STEP_SUMMARY
+              rm -f "$TDX_FILE"
             fi
-            echo "   SEV rootfs sha256: \`$SEV_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
           else
-            echo "ℹ️  SEV rootfs URL not configured — skipping SEV download" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️  TDX rootfs ISO unavailable; using pinned SHA for RTMR3" >> $GITHUB_STEP_SUMMARY
+            rm -f "$TDX_FILE"
           fi
+
+          SEV_REG_SHA=$(sha256sum "$SEV_REG_FILE" | cut -d' ' -f1)
+          TDX_REG_SHA=$(sha256sum "$TDX_REG_FILE" | cut -d' ' -f1)
+          echo "rootfs_mode=$ROOTFS_MODE" >> $GITHUB_OUTPUT
+          echo "sev_registry_path=$SEV_REG_FILE" >> $GITHUB_OUTPUT
+          echo "tdx_registry_path=$TDX_REG_FILE" >> $GITHUB_OUTPUT
+          echo "sev_registry_sha256=$SEV_REG_SHA" >> $GITHUB_OUTPUT
+          echo "tdx_registry_sha256=$TDX_REG_SHA" >> $GITHUB_OUTPUT
+          echo "📋 secretvm-verify@${{ steps.secretvm-config.outputs.verify_npm_version }} registries fetched" >> $GITHUB_STEP_SUMMARY
+          echo "   TDX: \`$TDX_REG_URL\`" >> $GITHUB_STEP_SUMMARY
+          echo "   SEV: \`$SEV_REG_URL\`" >> $GITHUB_STEP_SUMMARY
+          echo "   TDX rootfs sha256 (pin): \`$TDX_EXPECTED_SHA\`" >> $GITHUB_STEP_SUMMARY
+          echo "   SEV rootfs sha256 (pin): \`$SEV_EXPECTED_SHA\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Generate deployed compose with immutable digest
         id: generate-compose
@@ -666,11 +709,19 @@ jobs:
       - name: Compute RTMR3 (Intel TDX)
         id: compute-rtmr3
         run: |
+          TDX_PIN="${{ steps.secretvm-config.outputs.rootfs_tdx_sha256 }}"
           ROOTFS_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx.iso"
-          RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
-            /tmp/docker-compose.tee.deployed.yml \
-            "$ROOTFS_FILE" \
-            --json)
+          if [ -f "$ROOTFS_FILE" ]; then
+            RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
+              /tmp/docker-compose.tee.deployed.yml \
+              "$ROOTFS_FILE" \
+              --json)
+          else
+            RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
+              /tmp/docker-compose.tee.deployed.yml \
+              --rootfs-sha256="$TDX_PIN" \
+              --json)
+          fi
 
           RTMR3_HEX=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['rtmr3'])")
           COMPOSE_HASH=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['compose_sha256'])")
@@ -681,26 +732,12 @@ jobs:
           echo "   compose sha256: \`$COMPOSE_HASH\`" >> $GITHUB_STEP_SUMMARY
           echo "   rootfs sha256:  \`$ROOTFS_HASH\`" >> $GITHUB_STEP_SUMMARY
 
-      - name: Fetch SecretVM SEV artifact registry
-        id: sev-registry
-        if: steps.secretvm-config.outputs.rootfs_sev_url != ''
-        run: |
-          REGISTRY_URL="${{ steps.secretvm-config.outputs.sev_registry_url }}"
-          REGISTRY_FILE="/tmp/secretvm-artifacts/sev.json"
-          echo "⬇️  Fetching SEV artifact registry from $REGISTRY_URL..."
-          curl -L --retry 3 --retry-delay 5 -o "$REGISTRY_FILE" "$REGISTRY_URL"
-          REGISTRY_SHA=$(sha256sum "$REGISTRY_FILE" | cut -d' ' -f1)
-          echo "registry_path=$REGISTRY_FILE" >> $GITHUB_OUTPUT
-          echo "registry_sha256=$REGISTRY_SHA" >> $GITHUB_OUTPUT
-          echo "📋 SEV registry sha256: \`$REGISTRY_SHA\`" >> $GITHUB_STEP_SUMMARY
-          echo "   URL: \`$REGISTRY_URL\`" >> $GITHUB_STEP_SUMMARY
-
       - name: Compute SEV-SNP measurement (per template)
         id: compute-sev
-        if: steps.secretvm-config.outputs.rootfs_sev_url != ''
+        if: steps.secretvm-config.outputs.sev_registry_url != ''
         run: |
           SEV_OUT=$(python3 proxy-router/scripts/compute-sev-measurement.py \
-            --registry "${{ steps.sev-registry.outputs.registry_path }}" \
+            --registry "${{ steps.secretvm-artifacts.outputs.sev_registry_path }}" \
             --vm-type "${{ steps.secretvm-config.outputs.sev_registry_vm_type }}" \
             --artifacts-ver "${{ steps.secretvm-config.outputs.release }}" \
             --compose /tmp/docker-compose.tee.deployed.yml \
@@ -827,7 +864,7 @@ jobs:
               --arg ovmf "${{ steps.compute-sev.outputs.sev_ovmf_hash }}" \
               --arg cmdline "${{ steps.compute-sev.outputs.sev_kernel_cmdline }}" \
               --arg registry_url "${{ steps.secretvm-config.outputs.sev_registry_url }}" \
-              --arg registry_sha "${{ steps.sev-registry.outputs.registry_sha256 }}" \
+              --arg registry_sha "${{ steps.secretvm-artifacts.outputs.sev_registry_sha256 }}" \
               --arg small   "${{ steps.compute-sev.outputs.sev_measurement_small }}" \
               --arg medium  "${{ steps.compute-sev.outputs.sev_measurement_medium }}" \
               --arg large   "${{ steps.compute-sev.outputs.sev_measurement_large }}" \

--- a/docs/providers/full/sev-verification.mdx
+++ b/docs/providers/full/sev-verification.mdx
@@ -3,7 +3,7 @@ title: "AMD SEV-SNP verification"
 description: "How Phase 2 backend attestation works on AMD SEV-SNP: GCTX launch digest replay, family_id/image_id parsing, the SEV artifact registry, and differences from Intel TDX."
 audience: ["provider-full", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.7.0"
+last_verified: "v7.9.0"
 source: "proxy-router/docs/sev-verification.md"
 ---
 
@@ -170,7 +170,7 @@ This is how the docker-compose content gets measured into the SEV launch digest 
 
 ## SEV artifact registry
 
-The SEV registry is a JSON array at [sev.json](https://github.com/scrtlabs/secretvm-verify/blob/main/artifacts_registry/sev.json). Each entry contains all the data needed to recompute the GCTX launch digest:
+The SEV registry is a JSON array shipped in [secretvm-verify](https://www.npmjs.com/package/secretvm-verify) ([sev.json via jsDelivr](https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json); also on [PyPI](https://pypi.org/project/secretvm-verify/)). Each entry contains all the data needed to recompute the GCTX launch digest:
 
 | Field | Description |
 |-------|-------------|
@@ -202,7 +202,7 @@ The `family_id` field encodes the VM template name, which maps to a vCPU count:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SEV_ARTIFACT_REGISTRY_URL` | [sev.json on GitHub](https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json) | URL for the SEV-SNP artifact registry JSON |
+| `SEV_ARTIFACT_REGISTRY_URL` | [sev.json via npm](https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json) | URL for the SEV-SNP artifact registry JSON ([secretvm-verify](https://www.npmjs.com/package/secretvm-verify)) |
 | `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | `1h` | Shared refresh interval for both TDX and SEV registries |
 
 ## Code structure

--- a/docs/providers/full/tee-backend-verification.mdx
+++ b/docs/providers/full/tee-backend-verification.mdx
@@ -3,7 +3,7 @@ title: "TEE backend verification (Phase 2)"
 description: "How the provider's P-Node cryptographically verifies its backend LLM: full attestation flow, TLS binding, RTMR3 workload replay, GPU/NRAS verification, per-prompt fast verify, and known gaps."
 audience: ["provider-full", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.7.0"
+last_verified: "v7.9.0"
 source: "proxy-router/docs/tee-backend-verification.md"
 ---
 
@@ -248,8 +248,8 @@ Example: a model registered on-chain with the `tee` tag and `apiUrl` set to `htt
 |----------|----------|---------|-------------|
 | `TEE_PORTAL_URL` | Yes (for `tee`-tagged models) | — | SecretAI Portal API URL for CPU quote verification |
 | `TEE_IMAGE_REPO` | No | — | GHCR image repo for cosign attestation manifest verification (e.g. `ghcr.io/morpheusais/morpheus-lumerin-node-tee`). Used by consumer-side P-Node attestation to fetch the signed golden RTMR3 values for the provider image |
-| `ARTIFACT_REGISTRY_URL` | No | [tdx.csv](https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv) | URL to the TDX artifact registry CSV file. The default points to the official SecretVM artifact registry maintained by SCRT Labs |
-| `SEV_ARTIFACT_REGISTRY_URL` | No | [sev.json](https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json) | URL to the AMD SEV-SNP artifact registry JSON file |
+| `ARTIFACT_REGISTRY_URL` | No | [tdx.csv via npm](https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv) | URL to the TDX artifact registry CSV ([secretvm-verify on npm](https://www.npmjs.com/package/secretvm-verify) / [PyPI](https://pypi.org/project/secretvm-verify/)) |
+| `SEV_ARTIFACT_REGISTRY_URL` | No | [sev.json via npm](https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json) | URL to the AMD SEV-SNP artifact registry JSON |
 | `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | No | `1h` | How often to re-download the artifact registries (shared by TDX and SEV) |
 
 ## Health endpoint

--- a/docs/providers/full/tee-reference.mdx
+++ b/docs/providers/full/tee-reference.mdx
@@ -3,7 +3,7 @@ title: "TEE reference"
 description: "Build-time baked-in config, RTMR3 attestation, cosign image/manifest verification, and consumer-side verification steps for the -tee proxy-router image."
 audience: ["provider-full", "developer", "consumer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 source: "docs/02.3-proxy-router-tee.md"
 ---
 
@@ -300,43 +300,40 @@ See the conceptual breakdown in [TEE overview](/concepts/tee-overview), which mi
 
 ## Upgrading SecretVM artifacts
 
-When SCRT Labs publishes a new SecretVM release (e.g. `v0.0.25 → v0.0.26`), the rootfs changes and all RTMR3 values must be recomputed. The CI/CD pipeline is fully variabilized so updating requires only editing `.github/tee/secretvm.env`.
+When SCRT Labs publishes a new SecretVM release (e.g. `v0.0.31 → v0.0.32`), the rootfs changes and all RTMR3 / SEV measurements must be recomputed. The CI/CD pipeline is fully variabilized so updating requires only editing `.github/tee/secretvm.env`.
 
 ### When to upgrade
 
-SCRT Labs publishes at [github.com/scrtlabs/secret-vm-build/releases](https://github.com/scrtlabs/secret-vm-build/releases). No push notifications — check periodically:
+Source of truth for the Production artifacts version is the **SecretVM portal**. Cross-check digests against the published [secretvm-verify](https://www.npmjs.com/package/secretvm-verify) package (`data/tdx.csv` / `data/sev.json` — also on [PyPI](https://pypi.org/project/secretvm-verify/)):
 
 ```bash
-curl -s https://api.github.com/repos/scrtlabs/secret-vm-build/releases \
-  | jq '[.[] | {tag: .tag_name, prerelease: .prerelease, date: .published_at}] | .[0:5]'
+# TDX rootfs_data for prod / <release>
+curl -fsSL https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv | head
+# SEV rootfs_hash for prod / <release>
+curl -fsSL https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json | jq '.[0]'
 ```
 
-<Note>
-SCRT Labs sometimes marks new releases as **pre-release** on GitHub while already deploying them to the SecretVM portal. The `/releases/latest` API only returns non-prerelease versions, so always check the full list.
-</Note>
+Bump `SECRETVM_VERIFY_NPM_VERSION` (and the registry URLs) when SCRT publishes a newer package that includes the release you are pinning.
 
 ### How to upgrade
 
 <Steps>
   <Step title="Edit secretvm.env">
     ```bash
-    SECRETVM_RELEASE=v0.0.26
-    SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26/rootfs-prod-v0.0.26-tdx.iso
-    SECRETVM_ROOTFS_TDX_SHA256=
+    SECRETVM_RELEASE=v0.0.31
+    SECRETVM_VERIFY_NPM_VERSION=0.13.0
+    SECRETVM_TDX_REGISTRY_URL=https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv
+    SECRETVM_SEV_REGISTRY_URL=https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json
+    SECRETVM_ROOTFS_TDX_SHA256=<rootfs_data from tdx.csv for prod/v0.0.31>
+    SECRETVM_ROOTFS_SEV_SHA256=<rootfs_hash from sev.json for prod/v0.0.31>
     ```
-    `SECRETVM_ROOTFS_VARIANT` stays `rootfs-prod-tdx` unless naming changes.
+    `SECRETVM_ROOTFS_VARIANT` stays `rootfs-prod` unless naming changes. ISO download URLs are optional; CI uses the pinned SHA when the ISO host is unavailable.
   </Step>
   <Step title="Push and run CI/CD">
-    The pipeline downloads the new rootfs, computes its SHA-256, computes the new RTMR3, and embeds it in the signed manifest.
-  </Step>
-  <Step title="Pin the rootfs SHA-256">
-    Copy the SHA-256 from the GitHub Actions step summary back into `secretvm.env`:
-    ```bash
-    SECRETVM_ROOTFS_TDX_SHA256=<sha256-from-step-summary>
-    ```
+    The pipeline fetches the registries from the npm CDN, verifies the pins match, computes RTMR3 (from the pin or ISO) and SEV measurements, and embeds them in the signed manifest.
   </Step>
   <Step title="Rebuild providers">
-    Providers running older SecretVM versions will have mismatched RTMR3. They should redeploy on the current SecretVM release.
+    Providers running older SecretVM versions will have mismatched measurements. They should redeploy on the current SecretVM release.
   </Step>
 </Steps>
 
@@ -354,7 +351,8 @@ SCRT Labs sometimes marks new releases as **pre-release** on GitHub while alread
 | RTMR3 computation script | [`proxy-router/scripts/compute-rtmr3.py`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/proxy-router/scripts/compute-rtmr3.py) |
 | SecretVM artifact config | [`.github/tee/secretvm.env`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/.github/tee/secretvm.env) |
 | Sigstore cosign | https://github.com/sigstore/cosign |
-| SCRT Labs reproduce-mr | https://github.com/scrtlabs/reproduce-mr |
+| secretvm-verify (npm) | https://www.npmjs.com/package/secretvm-verify |
+| secretvm-verify (PyPI) | https://pypi.org/project/secretvm-verify/ |
 | SecretVM documentation | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines |
 | SecretVM CLI docs | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli |
 | SecretVM attestation portal | https://secretai.scrtlabs.com/attestation |

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -145,6 +145,7 @@ TEE_IMAGE_REPO=ghcr.io/morpheusais/morpheus-lumerin-node-tee
 # URL for the SecretVM TDX artifact registry CSV used to look up MRTD + RTMR0-2
 # during backend workload verification. Defaults to the official SCRT Labs
 # registry and can be left blank to use the built-in default.
-ARTIFACT_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv
+ARTIFACT_REGISTRY_URL=https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv
+SEV_ARTIFACT_REGISTRY_URL=https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json
 # How often the proxy-router re-downloads the artifact registry (default 1h).
 ARTIFACT_REGISTRY_REFRESH_INTERVAL=1h

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -3,7 +3,7 @@ title: "Env: proxy-router"
 description: "Every environment variable consumed by the proxy-router, with mainnet/testnet defaults and explicit precedence rules where two variables overlap."
 audience: ["provider-full", "provider-resale", "prosumer", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 source: "docs/proxy-router.all.env"
 ---
 
@@ -209,7 +209,8 @@ These are only consulted when at least one model in the marketplace is `tee`-tag
 |----------|---------|-------|
 | `TEE_PORTAL_URL` | `https://secretai.scrtlabs.com/api` | SecretAI Portal used to verify raw TDX CPU quotes |
 | `TEE_IMAGE_REPO` | `ghcr.io/morpheusais/morpheus-lumerin-node-tee` | GHCR repo where the consumer-side P-Node attestation fetches the signed golden manifest via cosign |
-| `ARTIFACT_REGISTRY_URL` | `https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv` | SecretVM TDX artifact registry CSV (MRTD + RTMR0-2 lookup) |
+| `ARTIFACT_REGISTRY_URL` | `https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv` | SecretVM TDX artifact registry CSV (MRTD + RTMR0-2 lookup). Served from the published [secretvm-verify](https://www.npmjs.com/package/secretvm-verify) package after the GitHub repo was removed. |
+| `SEV_ARTIFACT_REGISTRY_URL` | `https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json` | SecretVM SEV-SNP artifact registry JSON |
 | `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | `1h` | How often the proxy-router re-downloads the artifact registry |
 
 See [TEE overview](/concepts/tee-overview) and [TEE reference](/providers/full/tee-reference).

--- a/proxy-router/internal/attestation/artifacts_registry.go
+++ b/proxy-router/internal/attestation/artifacts_registry.go
@@ -14,7 +14,10 @@ import (
 )
 
 const (
-	DefaultRegistryURL             = "https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv"
+	// Bundled in the published secretvm-verify npm/PyPI packages after the
+	// scrtlabs/secretvm-verify GitHub repo was removed. Pin the npm version so
+	// registry contents stay reproducible; bump with SecretVM release pins.
+	DefaultRegistryURL             = "https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/tdx.csv"
 	DefaultRegistryRefreshInterval = 1 * time.Hour
 )
 

--- a/proxy-router/internal/attestation/sev_registry.go
+++ b/proxy-router/internal/attestation/sev_registry.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	DefaultSevRegistryURL = "https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json"
+	// See DefaultRegistryURL — registries ship inside secretvm-verify on npm/PyPI.
+	DefaultSevRegistryURL = "https://cdn.jsdelivr.net/npm/secretvm-verify@0.13.0/data/sev.json"
 )
 
 type SevArtifactRegistry struct {

--- a/proxy-router/scripts/compute-rtmr3.py
+++ b/proxy-router/scripts/compute-rtmr3.py
@@ -5,10 +5,16 @@ Compute expected RTMR3 (Intel TDX) for a SecretVM deployment.
 RTMR3 = replayRTMR(sha256(docker-compose), sha256(rootfs) [, sha256(docker-files)])
 
 Algorithm matches scrtlabs/reproduce-mr  (internal/mr.go  lines 642-657).
-Only requires the compose file and rootfs — no firmware/kernel/templates needed.
+Only requires the compose file and rootfs digest — no firmware/kernel/templates needed.
 
 Usage:
-    python3 compute-rtmr3.py <docker-compose.yaml> <rootfs.iso> [docker-files]
+    python3 compute-rtmr3.py <docker-compose.yaml> <rootfs.iso> [docker-files] [--json]
+    python3 compute-rtmr3.py <docker-compose.yaml> --rootfs-sha256=<hex> [--json]
+
+The --rootfs-sha256 form is for CI when the SecretVM rootfs ISO is not downloadable
+(scrtlabs/secret-vm-build GitHub releases were removed) but the SHA-256 is still
+pinned in .github/tee/secretvm.env and published in secretvm-verify's tdx.csv
+(npm/PyPI data/).
 
 Output (stdout):
     96-char lowercase hex RTMR3 value  (SHA-384, 48 bytes)
@@ -50,25 +56,59 @@ def replay_rtmr(entries: list[str]) -> str:
 
 def main() -> None:
     json_output = "--json" in sys.argv
-    positional = [a for a in sys.argv[1:] if not a.startswith("--")]
+    rootfs_sha_arg = None
+    for a in sys.argv[1:]:
+        if a.startswith("--rootfs-sha256="):
+            rootfs_sha_arg = a.split("=", 1)[1].strip().lower().removeprefix("0x")
+        elif a == "--rootfs-sha256":
+            print("ERROR: use --rootfs-sha256=<hex>", file=sys.stderr)
+            sys.exit(2)
 
-    if len(positional) < 2:
+    positional = [
+        a for a in sys.argv[1:]
+        if not a.startswith("--")
+    ]
+
+    if not positional:
         print(
-            f"Usage: {sys.argv[0]} <docker-compose.yaml> <rootfs.iso> [docker-files] [--json]",
+            f"Usage: {sys.argv[0]} <docker-compose.yaml> <rootfs.iso> [docker-files] [--json]\n"
+            f"       {sys.argv[0]} <docker-compose.yaml> --rootfs-sha256=<hex> [--json]",
             file=sys.stderr,
         )
         sys.exit(1)
 
     compose_path = positional[0]
-    rootfs_path = positional[1]
-
     compose_hash = sha256_file(compose_path)
-    rootfs_hash = sha256_file(rootfs_path)
+
+    if rootfs_sha_arg is not None:
+        if len(rootfs_sha_arg) != 64 or any(c not in "0123456789abcdef" for c in rootfs_sha_arg):
+            print(
+                f"ERROR: --rootfs-sha256 must be 64 hex chars, got {len(rootfs_sha_arg)} chars",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        rootfs_hash = rootfs_sha_arg
+        if len(positional) > 1:
+            print(
+                "ERROR: do not pass a rootfs.iso path when using --rootfs-sha256",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+    else:
+        if len(positional) < 2:
+            print(
+                f"Usage: {sys.argv[0]} <docker-compose.yaml> <rootfs.iso> [docker-files] [--json]\n"
+                f"       {sys.argv[0]} <docker-compose.yaml> --rootfs-sha256=<hex> [--json]",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        rootfs_hash = sha256_file(positional[1])
 
     entries = [compose_hash, rootfs_hash]
 
     docker_files_hash = None
-    if len(positional) > 2:
+    # docker-files only applies when hashing a real ISO (positional[2])
+    if rootfs_sha_arg is None and len(positional) > 2:
         docker_files_hash = sha256_file(positional[2])
         entries.append(docker_files_hash)
 


### PR DESCRIPTION
## Summary
- Point TDX/SEV artifact registry defaults and CI at `secretvm-verify@0.13.0` on npm (jsDelivr CDN) after the SCRT Labs GitHub repos were removed.
- Cross-check pinned rootfs SHAs against `tdx.csv` / `sev.json`; compute RTMR3 from the pin when the legacy ISO download 404s.
- Extend `compute-rtmr3.py` with `--rootfs-sha256` and update TEE docs/env examples.

## Test plan
- [ ] CI TEE job fetches registries from jsDelivr and reports pin match for `prod/v0.0.31`
- [ ] RTMR3 computed via `--rootfs-sha256` when ISO unavailable
- [ ] SEV measurement step still produces per-template digests from the npm registry
- [ ] Proxy-router default registry URLs resolve (integration / unit paths that hit CDN)


Made with [Cursor](https://cursor.com)