### PR TITLE
docs: nodedocs agent-friendly export

### DIFF
--- a/.cursor/rules/morpheus.mdc
+++ b/.cursor/rules/morpheus.mdc
@@ -10,6 +10,7 @@ This repository has nuance that generic web knowledge gets wrong. **Before answe
 ## Canonical sources
 
 - Documentation site: `/docs/` (Mintlify; preview with `mint dev` in that folder)
+- Agent corpus: [`https://nodedocs.mor.org/llms-full.txt`](https://nodedocs.mor.org/llms-full.txt) — non-browser page fetches return clean Markdown; MCP at `/mcp`
 - API schema: [`proxy-router/docs/swagger.yaml`](../../proxy-router/docs/swagger.yaml)
 - Networks and contract addresses: [`docs/get-started/networks-and-tokens.mdx`](../../docs/get-started/networks-and-tokens.mdx)
 - TEE attestation reference: [`docs/providers/full/tee-reference.mdx`](../../docs/providers/full/tee-reference.mdx) and [`docs/providers/full/tee-backend-verification.mdx`](../../docs/providers/full/tee-backend-verification.mdx)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,12 @@ If you are an LLM (Claude, GPT, Gemini, Copilot, Cursor, etc.) reading this repo
 ## How to load documentation (follow this order)
 
 1. **This file** — hard rules, quick lookup, and repo pointers. No network required.
-2. **[`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)** — **fetch this** for the complete documentation corpus as plain markdown (~280 KB). Every page title in the export matches a `# Heading` section. This is the primary ingestion path.
-3. **[`llms.txt`](https://nodedocs.mor.org/llms.txt)** — lightweight page index (title, description, URL per page). Use this to find the right slug before searching `llms-full.txt`.
-4. **Do not scrape individual `nodedocs.mor.org` page URLs** — they return Mintlify HTML, not markdown. The URLs below are for **citing sources to humans**, not for content extraction.
+2. **[`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)** — **fetch this** for the complete documentation corpus as plain markdown (~350 KB). Every page title in the export matches a `# Heading` section. This is the primary ingestion path.
+3. **[`llms.txt`](https://nodedocs.mor.org/llms.txt)** — lightweight page index (title, description, URL per page). Links point at per-page `.md` files.
+4. **Page URLs are agent-readable for non-browsers** — CloudFront serves clean Markdown when `Accept` does not include `text/html` (bare `curl`, most agent HTTP clients). Browsers still get the Mintlify UI. You can also append `.md` (e.g. [`/ai/myths.md`](https://nodedocs.mor.org/ai/myths.md)) or use MCP at [`https://nodedocs.mor.org/mcp`](https://nodedocs.mor.org/mcp).
+5. **Do not rely on rendering the JS HTML UI** — prefer `llms-full.txt`, `.md` URLs, or a non-browser fetch of the page URL. Citation URLs below remain the human-facing paths.
 
-Published site (human browsing): [nodedocs.mor.org](https://nodedocs.mor.org). Source files live in `/docs/` and are built with Mintlify.
+Published site: [nodedocs.mor.org](https://nodedocs.mor.org). Source files live in `/docs/` and are built with Mintlify.
 
 ## Priority reading (find these sections in `llms-full.txt`)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ To load the full documentation corpus in one fetch:
 
 | Resource | URL | Use |
 |----------|-----|-----|
-| Full corpus (preferred) | [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt) | Complete markdown export — fetch this, do not scrape HTML pages |
-| Page index | [`llms.txt`](https://nodedocs.mor.org/llms.txt) | Titles, descriptions, and slugs for every page |
+| Full corpus (preferred) | [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt) | Complete markdown export — primary ingestion path |
+| Page index | [`llms.txt`](https://nodedocs.mor.org/llms.txt) | Titles, descriptions, and per-page `.md` links |
+| Page Markdown | append `.md` or non-browser fetch | Same page URL returns clean Markdown when `Accept` lacks `text/html` |
+| Docs MCP | [`/mcp`](https://nodedocs.mor.org/mcp) | Search / retrieve pages without scraping HTML |
 
-Individual nodedocs page URLs are for human browsing and citation only. See `AGENTS.md` for priority reading slugs and anti-hallucination rules.
+See `AGENTS.md` for priority reading slugs and anti-hallucination rules.

--- a/docs/ai/llm-prompt-cheatsheet.mdx
+++ b/docs/ai/llm-prompt-cheatsheet.mdx
@@ -8,6 +8,12 @@ last_verified: "v7.9.0"
 
 If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morpheus questions, follow these rules. They will keep you out of the most common hallucination traps.
 
+## How to load this site
+
+- Prefer [`https://nodedocs.mor.org/llms-full.txt`](https://nodedocs.mor.org/llms-full.txt) for the full corpus, or [`llms.txt`](https://nodedocs.mor.org/llms.txt) for the index.
+- Non-browser fetches of any page URL return clean Markdown (no JS). Appending `.md` also works. Docs MCP: [`https://nodedocs.mor.org/mcp`](https://nodedocs.mor.org/mcp).
+- Do not depend on a headless browser or Chrome extension to read nodedocs.
+
 ## Rules of engagement
 
 1. **Never invent contract addresses, chain IDs, or token addresses.** Always cite [Networks and tokens](/get-started/networks-and-tokens). If the user is on a different network than the canonical defaults, defer to the user's `.env`.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -66,4 +66,11 @@ These pages link out to **live data** that changes too often to mirror:
 
 ## For AI agents
 
-If you are an LLM or coding agent reading this repo, start with the [AI knowledge](/ai/myths) section and the [`AGENTS.md`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/AGENTS.md) file at the repo root. Mintlify also publishes `/llms.txt` and `/llms-full.txt` indexes for this site.
+If you are an LLM or coding agent, **do not scrape the browser HTML** — non-browser fetches of any page URL on this site return clean Markdown. Preferred ingestion paths:
+
+- Full corpus: [`https://nodedocs.mor.org/llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)
+- Page index: [`https://nodedocs.mor.org/llms.txt`](https://nodedocs.mor.org/llms.txt)
+- Per-page Markdown: append `.md` (e.g. [`/ai/myths.md`](https://nodedocs.mor.org/ai/myths.md)) or fetch the page URL without `Accept: text/html`
+- Docs search MCP: [`https://nodedocs.mor.org/mcp`](https://nodedocs.mor.org/mcp)
+
+Start with the [AI knowledge](/ai/myths) section and the repo-root [`AGENTS.md`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/AGENTS.md).

--- a/docs/scripts/generate-llms-txt.mjs
+++ b/docs/scripts/generate-llms-txt.mjs
@@ -3,8 +3,10 @@
  * Generate llms.txt, llms-full.txt, and per-page *.md from docs.json + MDX.
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/generate-llms-txt.mjs [docsDir] [outDir]
  *
- * Per-page markdown makes "View as Markdown" / Accept: text/markdown work on the
- * self-hosted S3 site (Mintlify cloud serves these dynamically; mint export does not).
+ * Self-hosted S3 export cannot use Mintlify cloud's dynamic markdown / Accept
+ * negotiation. This script emits clean per-page *.md (MDX components stripped
+ * to plain markdown) plus llms indexes so CloudFront can serve non-browser
+ * clients readable text at the same page URLs.
  */
 import fs from "fs";
 import path from "path";
@@ -17,6 +19,17 @@ const siteUrl = (process.env.SITE_URL ?? "https://nodedocs.mor.org").replace(/\/
 
 const docsJson = JSON.parse(fs.readFileSync(path.join(docsDir, "docs.json"), "utf8"));
 
+const AGENT_INSTRUCTIONS = [
+  "## Agent Instructions",
+  "",
+  `- Non-browser fetches of page URLs on this site return clean Markdown (not the JS UI). Prefer \`${siteUrl}/llms-full.txt\` for the full corpus, or \`${siteUrl}/llms.txt\` for the index.`,
+  `- Per-page Markdown is also at \`<page-url>.md\` (homepage: \`${siteUrl}/index.md\`).`,
+  `- Docs search MCP: \`${siteUrl}/mcp\` (discovery: \`${siteUrl}/.well-known/mcp\`).`,
+  "- Never invent contract addresses, chain IDs, token addresses, or live bid/model counts. Cite Networks and tokens; link active.mor.org for live data.",
+  "- Never claim Morpheus runs inference — independent providers do. Opening a session escrows MOR; it does not spend it.",
+  "",
+].join("\n");
+
 function walkNavItems(items, slugs) {
   for (const item of items ?? []) {
     if (typeof item === "string") {
@@ -28,7 +41,7 @@ function walkNavItems(items, slugs) {
 }
 
 function collectSlugs() {
-  const slugs = [];
+  const slugs = ["index"];
   for (const tab of docsJson.navigation?.tabs ?? []) {
     for (const group of tab.groups ?? []) {
       walkNavItems(group.pages, slugs);
@@ -54,9 +67,88 @@ function slugToUrl(slug) {
   return slug === "index" ? siteUrl : `${siteUrl}/${slug}`;
 }
 
+function slugToMdUrl(slug) {
+  return slug === "index" ? `${siteUrl}/index.md` : `${siteUrl}/${slug}.md`;
+}
+
 function slugToMdxPath(slug) {
   if (slug === "index") return path.join(docsDir, "index.mdx");
   return path.join(docsDir, `${slug}.mdx`);
+}
+
+/**
+ * Convert Mintlify MDX components to plain markdown for agent consumption.
+ * Leaves fenced code blocks (including mermaid) untouched.
+ */
+function mdxToCleanMarkdown(body) {
+  const fences = [];
+  let text = body.replace(/```[\s\S]*?```/g, (block) => {
+    const token = `@@FENCE_${fences.length}@@`;
+    fences.push(block);
+    return token;
+  });
+
+  // Accordion / AccordionGroup
+  text = text.replace(/<\/?AccordionGroup>/g, "");
+  text = text.replace(
+    /<Accordion\s+title="([^"]*)"\s*>\s*([\s\S]*?)\s*<\/Accordion>/g,
+    (_, title, inner) => `\n### ${title.trim()}\n\n${inner.trim()}\n`
+  );
+
+  // Steps
+  text = text.replace(/<\/?Steps>/g, "");
+  text = text.replace(/<Step\s+title="([^"]*)"\s*>\s*([\s\S]*?)\s*<\/Step>/g, (_, title, inner) => {
+    return `\n### ${title.trim()}\n\n${inner.trim()}\n`;
+  });
+  text = text.replace(/<\/?Step>/g, "");
+
+  // Cards
+  text = text.replace(/<CardGroup[^>]*>/g, "");
+  text = text.replace(/<\/CardGroup>/g, "");
+  text = text.replace(
+    /<Card\s+([^>]*)>\s*([\s\S]*?)\s*<\/Card>/g,
+    (_, attrs, inner) => {
+      const title = (attrs.match(/title="([^"]*)"/) || [])[1] || "";
+      const href = (attrs.match(/href="([^"]*)"/) || [])[1] || "";
+      const bodyInner = inner.trim();
+      if (title && href) return `\n- **[${title}](${href})** — ${bodyInner}\n`;
+      if (title) return `\n- **${title}** — ${bodyInner}\n`;
+      return `\n${bodyInner}\n`;
+    }
+  );
+
+  // Callouts → blockquotes
+  for (const tag of ["Note", "Warning", "Tip", "Info", "Check", "Danger"]) {
+    const re = new RegExp(`<${tag}[^>]*>\\s*([\\s\\S]*?)\\s*<\\/${tag}>`, "g");
+    text = text.replace(re, (_, inner) => {
+      const quoted = inner
+        .trim()
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      return `\n${quoted}\n`;
+    });
+  }
+
+  // Tabs (keep content, drop chrome)
+  text = text.replace(/<\/?Tabs>/g, "");
+  text = text.replace(/<Tab\s+title="([^"]*)"\s*>\s*([\s\S]*?)\s*<\/Tab>/g, (_, title, inner) => {
+    return `\n### ${title.trim()}\n\n${inner.trim()}\n`;
+  });
+
+  // Frame / ResponseField / ParamField wrappers — keep inner text
+  text = text.replace(/<\/?(?:Frame|ResponseField|ParamField)[^>]*>/g, "");
+
+  // Self-closing or leftover JSX-ish tags that shouldn't appear in agent md
+  text = text.replace(/<\/?[A-Z][A-Za-z0-9]*\b[^>]*\/?>/g, "");
+
+  // Collapse excess blank lines
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  for (let i = 0; i < fences.length; i++) {
+    text = text.replace(`@@FENCE_${i}@@`, fences[i]);
+  }
+  return text.trim();
 }
 
 function writePageMarkdown(slug, title, url, body) {
@@ -65,7 +157,16 @@ function writePageMarkdown(slug, title, url, body) {
       ? path.join(outDir, "index.md")
       : path.join(outDir, `${slug}.md`);
   fs.mkdirSync(path.dirname(mdPath), { recursive: true });
-  const md = `# ${title}\n\nSource: ${url}\n\n${body.trim()}\n`;
+  const md = [
+    `# ${title}`,
+    "",
+    `Source: ${url}`,
+    "",
+    AGENT_INSTRUCTIONS.trimEnd(),
+    "",
+    body.trim(),
+    "",
+  ].join("\n");
   fs.writeFileSync(mdPath, md);
 }
 
@@ -81,10 +182,12 @@ for (const slug of collectSlugs()) {
   const title = meta.title ?? meta.sidebarTitle ?? slug;
   const description = meta.description ?? "";
   const url = slugToUrl(slug);
+  const mdUrl = slugToMdUrl(slug);
+  const clean = mdxToCleanMarkdown(body);
 
-  entries.push({ title, description, url });
-  fullSections.push(`# ${title}\n\nSource: ${url}\n\n${body.trim()}\n`);
-  writePageMarkdown(slug, title, url, body);
+  entries.push({ title, description, url: mdUrl, htmlUrl: url });
+  fullSections.push(`# ${title}\n\nSource: ${url}\n\n${clean}\n`);
+  writePageMarkdown(slug, title, url, clean);
   mdCount += 1;
 }
 
@@ -97,6 +200,8 @@ const llmsTxt = [
   `# ${siteName}`,
   "",
   `> ${siteDescription}`,
+  "",
+  AGENT_INSTRUCTIONS.trimEnd(),
   "",
   "## Pages",
   "",
@@ -112,6 +217,8 @@ const llmsFullTxt = [
   `# ${siteName} — full text export`,
   "",
   `> ${siteDescription}`,
+  "",
+  AGENT_INSTRUCTIONS.trimEnd(),
   "",
   ...fullSections,
 ].join("\n\n");

--- a/docs/scripts/postprocess-export.mjs
+++ b/docs/scripts/postprocess-export.mjs
@@ -36,6 +36,26 @@ execSync(
   { stdio: "inherit", env: { ...process.env, SITE_URL: siteUrl } }
 );
 
+// Agent discovery aids (Mintlify cloud hosts these; mint export does not).
+const llmsTxtPath = path.join(siteDir, "llms.txt");
+if (fs.existsSync(llmsTxtPath)) {
+  const wellKnownDir = path.join(siteDir, ".well-known");
+  fs.mkdirSync(wellKnownDir, { recursive: true });
+  fs.copyFileSync(llmsTxtPath, path.join(wellKnownDir, "llms.txt"));
+  const robots = [
+    "User-agent: *",
+    "Allow: /",
+    "",
+    `# LLM / agent corpus`,
+    `Sitemap: ${siteUrl}/llms.txt`,
+    `# Full docs as plain text: ${siteUrl}/llms-full.txt`,
+    `# Per-page markdown: append .md to any docs path (or fetch without Accept: text/html)`,
+    "",
+  ].join("\n");
+  fs.writeFileSync(path.join(siteDir, "robots.txt"), robots);
+  console.log("Wrote robots.txt and .well-known/llms.txt");
+}
+
 const pagefindSnippet = `
 <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
 <style>


### PR DESCRIPTION
## Summary
- Makes [nodedocs.mor.org](https://nodedocs.mor.org) readable for AI agents without a browser: non-browser fetches return clean Markdown; `/.md` works; Accordion/MDX stripped in exports; `llms.txt` points at `.md` URLs.
- Validated on **nodedocs.dev.mor.org** after `dev` → `test` ([#851](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/851)): bare curl → markdown, browser UI unchanged, MCP discovery OK.
- Pairs with already-applied Infra CloudFront Accept negotiation + MCP on prd/dev.

**Docs-only — no product release.** `CI-CD` (`build.yml`) path filters exclude `docs/**`, so this will not cut a `v7.10.0` (or any) release tag. Only the Docs workflow deploys nodedocs.

## Test plan
- [ ] Docs workflow deploys to **nodedocs.mor.org** on merge
- [ ] Bare `curl https://nodedocs.mor.org/` and `/ai/myths` → `text/markdown`
- [ ] Browser with `Accept: text/html` still gets the Mintlify UI
- [ ] `https://nodedocs.mor.org/.md` → 200 markdown
- [ ] `/ai/myths.md` has no Accordion tags; myth titles as `###` headings
- [ ] `Link` / `X-Llms-Txt` headers present; `/.well-known/mcp` discovery OK

**Merge with a regular merge commit (do not squash)** — Pattern A promote `test` → `main`.


Made with [Cursor](https://cursor.com)