### PR TITLE
docs: split STORE vs FORWARD chat-context flags

### DIFF
--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -3,7 +3,7 @@ title: "Env: proxy-router"
 description: "Every environment variable consumed by the proxy-router, with mainnet/testnet defaults and explicit precedence rules where two variables overlap."
 audience: ["provider-full", "provider-resale", "prosumer", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.9.0"
+last_verified: "2026-08-24"
 source: "docs/proxy-router.all.env"
 ---
 
@@ -85,6 +85,8 @@ Mismatch (e.g. `subscriptions=true` with HTTPS endpoint) makes the node fail to 
 ### `PROXY_STORE_CHAT_CONTEXT` is TEE-frozen
 
 In the **`-tee` image** this is hard-coded `false` at build time and **cannot be overridden at runtime**. Setting it in the env has no effect inside a TEE deployment. See [TEE reference](/providers/full/tee-reference).
+
+Storage and forwarding are independent. `PROXY_STORE_CHAT_CONTEXT` persists chats for `/v1/chats`. `PROXY_FORWARD_CHAT_CONTEXT` (default `false`) prepends that stored history onto the next prompt — opt-in for clients that send only the latest turn. OpenAI-compatible clients that already send the full `messages[]` should leave forwarding off.
 
 ---
 

--- a/proxy-router/.env.example
+++ b/proxy-router/.env.example
@@ -41,6 +41,10 @@ ETH_NODE_USE_SUBSCRIPTIONS=false
 ETH_NODE_ADDRESS=
 ETH_NODE_LEGACY_TX=false
 PROXY_STORE_CHAT_CONTEXT=true
+# Prepend stored history to prompts. Default false — opt-in for latest-turn-only
+# clients (the bundled Desktop UI sets this true). Leave off if the client
+# already sends the full messages[] transcript.
+PROXY_FORWARD_CHAT_CONTEXT=false
 PROXY_STORAGE_PATH=./data/
 LOG_COLOR=true
 

--- a/proxy-router/.env.example.win
+++ b/proxy-router/.env.example.win
@@ -31,6 +31,10 @@ ETH_NODE_USE_SUBSCRIPTIONS=false
 ETH_NODE_ADDRESS=
 ETH_NODE_LEGACY_TX=false
 PROXY_STORE_CHAT_CONTEXT=true
+# Prepend stored history to prompts. Default false — opt-in for latest-turn-only
+# clients (the bundled Desktop UI sets this true). Leave off if the client
+# already sends the full messages[] transcript.
+PROXY_FORWARD_CHAT_CONTEXT=false
 PROXY_STORAGE_PATH=./data/
 LOG_COLOR=true
 

--- a/proxy-router/readme.md
+++ b/proxy-router/readme.md
@@ -1,38 +1,22 @@
-## Environment Variables: 
+## Environment Variables:
 
-`PROXY_STORE_CHAT_CONTEXT`
+Chat context is two independent flags. **Storing** history does not prepend it onto the next prompt.
 
-- **Type:** Boolean
-- **Purpose:** Controls whether the proxy-router stores chat contexts locally.
+### `PROXY_STORE_CHAT_CONTEXT` (default `true`)
 
-#### When `PROXY_STORE_CHAT_CONTEXT` is set to `TRUE`
+Persist chats to local files for the history drawer and `/v1/chats` (see swagger). Frozen `false` in `-tee` images.
 
-- **Local Storage of Chats:**
-  - The proxy saves chat sessions to local files.
-  - Chat histories are maintained, allowing for persistent conversations.
-  
-- **API Operations:** (check swagger - `/v1/chats`)
-  - **Retrieve Chats:** Access stored chats via API endpoints.
-  - **Update Titles:** Modify chat titles using API calls.
-  - **Delete Chats:** Remove chat sessions through the API.
+- **`true`:** save sessions locally; list / rename / delete via the chats API. Send a stable `chat_id` header if you want turns grouped into one conversation.
+- **`false`:** nothing is persisted. Clients must send the full `messages[]` transcript each request.
 
-- **Using `chat_id`:**
-  - Include a `chat_id` in the request header.
-  - The proxy-router automatically injects the corresponding chat context.
-  - **Request Simplification:** Only the latest message needs to be sent in the request body.
+### `PROXY_FORWARD_CHAT_CONTEXT` (default `false`)
 
-#### When `PROXY_STORE_CHAT_CONTEXT` is set to `FALSE`
+Prepend stored history onto the outgoing prompt. Requires store on and a reused `chat_id`.
 
-- **No Chat Storage:**
-  - The proxy-router does not save any chat sessions locally.
-  
-- **Client-Side Context Management:**
-  - Clients must include the entire conversation history in each request.
-  - The proxy-router forwards the request to the AI model without adding any context.
+- **`false` (default):** the client owns the transcript. Leave this off for OpenAI-compatible clients that already send the full `messages[]` — otherwise context is duplicated.
+- **`true`:** opt-in for clients that send only the latest turn (the bundled Desktop UI sets this). The router prepends stored user/assistant turns before the new prompt.
 
----
-
-Ensure the proxy-router is restarted after changing the environment variable to apply the new configuration.
+Restart the proxy-router after changing either variable.
 
 ## CapacityPolicy strategies (models-config.json):
 


### PR DESCRIPTION
## Summary
- Correct `proxy-router/readme.md`: storing chat history is not the same as prepending it. `PROXY_FORWARD_CHAT_CONTEXT` defaults to `false` after #857; Desktop opts in.
- Pin `PROXY_FORWARD_CHAT_CONTEXT=false` in `.env.example` / `.env.example.win`.
- Note the same split on the nodedocs env page (`docs/reference/env-proxy-router.mdx`).

Follow-up to #857 / promote #858. Docs only.

## Test plan
- [ ] Read the readme section: STORE = persist `/v1/chats`; FORWARD = prepend (opt-in)
- [ ] Confirm example env files show FORWARD=false and do not imply latest-turn-only clients
- [ ] Confirm env-proxy-router.mdx table still says FORWARD default `false`


Made with [Cursor](https://cursor.com)