### PR TITLE
docs: Railway provider path + Intern walkthrough video

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Read the **AI knowledge** pages before answering user questions:
 | Consumer | `consumers/quickstart` | https://nodedocs.mor.org/consumers/quickstart |
 | Prosumer (agents) | `prosumers/overview` | https://nodedocs.mor.org/prosumers/overview |
 | Provider — Full P-Node | `providers/full/quickstart` | https://nodedocs.mor.org/providers/full/quickstart |
+| Provider — Railway (GHCR) | `providers/full/proxy-router-railway` | https://nodedocs.mor.org/providers/full/proxy-router-railway — video https://youtu.be/-z-EPK11qmM |
 | Provider — TEE / SecretVM | `providers/full/secretvm-quickstart` | https://nodedocs.mor.org/providers/full/secretvm-quickstart |
 | Provider — Resale | `providers/resale/overview` | https://nodedocs.mor.org/providers/resale/overview |
 | Developer (proxy-router API) | `reference/api-overview` | https://nodedocs.mor.org/reference/api-overview |
@@ -81,6 +82,7 @@ Read the **AI knowledge** pages before answering user questions:
 | "How do I install as a consumer?" | `consumers/quickstart` | https://nodedocs.mor.org/consumers/quickstart |
 | "How do I become a provider?" | `get-started/quickstart-provider` | https://nodedocs.mor.org/get-started/quickstart-provider |
 | "How do I run TEE?" | `providers/full/secretvm-quickstart` | https://nodedocs.mor.org/providers/full/secretvm-quickstart |
+| "How do I run a provider on Railway?" | `providers/full/proxy-router-railway` | https://nodedocs.mor.org/providers/full/proxy-router-railway — https://youtu.be/-z-EPK11qmM |
 | "What contract address?" | `get-started/networks-and-tokens` | https://nodedocs.mor.org/get-started/networks-and-tokens |
 | "Where can I see live status?" | — | https://active.mor.org |
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You will need both **MOR** (for stake / fees / session payment) and **ETH on BAS
 |------|-----------|
 | Consumer (chat) | [Consumer quickstart](https://nodedocs.mor.org/get-started/quickstart-consumer) |
 | Provider (host your own model) | [Provider quickstart](https://nodedocs.mor.org/get-started/quickstart-provider) |
+| Provider on Railway (same GHCR image) | [Railway docs](https://nodedocs.mor.org/providers/full/proxy-router-railway) · [video](https://youtu.be/-z-EPK11qmM) |
 | TEE provider (SecretVM) | [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart) |
 | Resale provider | [Resale overview](https://nodedocs.mor.org/providers/resale/overview) |
 | Prosumer / agent | [Prosumer overview](https://nodedocs.mor.org/prosumers/overview) |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
               "providers/full/quickstart",
               "providers/full/model-setup",
               "providers/full/proxy-router-docker",
+              "providers/full/proxy-router-railway",
               "providers/full/proxy-router-akash",
               "providers/full/aws",
               "providers/full/tee-reference",

--- a/docs/get-started/quickstart-provider.mdx
+++ b/docs/get-started/quickstart-provider.mdx
@@ -21,6 +21,9 @@ This page is the high-level checklist. For the full setup, branch into one of:
   <Card title="Docker" icon="docker" href="/providers/full/proxy-router-docker">
     Containerized proxy-router only.
   </Card>
+  <Card title="Railway" icon="cloud" href="/providers/full/proxy-router-railway">
+    Same GHCR image on Railway. [Video walkthrough](https://youtu.be/-z-EPK11qmM).
+  </Card>
   <Card title="AWS EC2" icon="aws" href="/providers/full/aws">
     Two-instance EC2 setup (LLM + proxy-router).
   </Card>

--- a/docs/providers/full/proxy-router-docker.mdx
+++ b/docs/providers/full/proxy-router-docker.mdx
@@ -13,6 +13,8 @@ The proxy-router is a critical component that monitors the BASE blockchain and m
 
 The official image is on GHCR: `ghcr.io/morpheusais/morpheus-lumerin-node:latest`. Built per release from the main branch. Browse: [MorpheusAIs Packages](https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node).
 
+To run that same image on Railway instead of a local Docker host, see [Proxy-router on Railway](/providers/full/proxy-router-railway) (includes an [11-minute walkthrough](https://youtu.be/-z-EPK11qmM)).
+
 For TEE-hardened images (`-tee` suffix), see [SecretVM quickstart](/providers/full/secretvm-quickstart) and [TEE reference](/providers/full/tee-reference).
 
 ## Pre-requisites

--- a/docs/providers/full/proxy-router-railway.mdx
+++ b/docs/providers/full/proxy-router-railway.mdx
@@ -9,7 +9,7 @@ last_verified: "v7.5.0"
 Railway is a hosted path for the same **GHCR image** as [Docker](/providers/full/proxy-router-docker). Use it when you want a public TCP `:3333` and HTTPS admin without running the box yourself.
 
 <Note>
-  11-minute walkthrough (Morpheus Intern): [How to Become a Morpheus AI Provider on Railway](https://youtu.be/-z-EPK11qmM)
+  11-minute walkthrough (Morpheus Intern): [AI Inference Node on Railway in 11 Min (No GPU)](https://youtu.be/-z-EPK11qmM)
 </Note>
 
 ## What the video covers

--- a/docs/providers/full/proxy-router-railway.mdx
+++ b/docs/providers/full/proxy-router-railway.mdx
@@ -1,0 +1,42 @@
+---
+title: "Proxy-router on Railway"
+description: "Deploy the official GHCR proxy-router image on Railway and register as a Morpheus provider. Includes a walkthrough video."
+audience: ["provider-full", "provider-resale"]
+product: ["proxy-router"]
+last_verified: "v7.5.0"
+---
+
+Railway is a hosted path for the same **GHCR image** as [Docker](/providers/full/proxy-router-docker). Use it when you want a public TCP `:3333` and HTTPS admin without running the box yourself.
+
+<Note>
+  11-minute walkthrough (Morpheus Intern): [How to Become a Morpheus AI Provider on Railway](https://youtu.be/-z-EPK11qmM)
+</Note>
+
+## What the video covers
+
+| Time | Step |
+|------|------|
+| 0:00 | What this is |
+| 0:20 | Create a Railway project |
+| 0:33 | Deploy `ghcr.io/morpheusais/morpheus-lumerin-node` |
+| 0:53 | Env vars (RPC, wallet, models) |
+| 2:39 | Models config (pass-through example) |
+| 4:06 | TCP proxy on port **3333** |
+| 4:22 | Volume at `/app/data` |
+| 4:42 | Deploy |
+| 5:19 | Public domain for admin port **8082** |
+| 6:21 | Reachability check |
+| 6:38 | Connect [MyProvider](/providers/full/myprovider-gui) |
+| 7:25 | Register on-chain and stake |
+| 8:17 | Post a model bid |
+| 9:33 | Confirm on [active.mor.org](https://active.mor.org) |
+| 10:17 | Stake vs emissions (earn only up to stake) |
+
+## Do this, not that
+
+- Same image and env contract as [Docker](/providers/full/proxy-router-docker). Set `ETH_NODE_ADDRESS` to **your** Alchemy/Infura BASE URL — do not rely on the public RPC fallback.
+- Expose **3333** to the marketplace. Treat **8082** as admin: set a real username/password; do not leave `admin`/`admin` on a public hostname.
+- Prefer bidding on an existing `modelId` from [active.mor.org](https://active.mor.org/status). Every `postModelBid` charges a non-refundable fee — finish config before the first bid. See [Pricing](/providers/full/pricing) and [Register on chain](/providers/full/register-onchain).
+- After deploy, run [Verify your provider setup](/providers/full/verify-setup).
+
+This page does not replace the Docker/env reference. After the video, use those pages for the exact variable list.

--- a/docs/providers/full/quickstart.mdx
+++ b/docs/providers/full/quickstart.mdx
@@ -7,7 +7,7 @@ last_verified: "v7.6.0"
 source: "docs/02-provider-setup.md"
 ---
 
-This page covers a **non-TEE provider** running on your own infrastructure. For TEE-hardened deployment on SecretVM, see [SecretVM quickstart](/providers/full/secretvm-quickstart). Hosted alternatives: [Docker](/providers/full/proxy-router-docker), [AWS EC2](/providers/full/aws), or [Akash](/providers/full/proxy-router-akash).
+This page covers a **non-TEE provider** running on your own infrastructure. For TEE-hardened deployment on SecretVM, see [SecretVM quickstart](/providers/full/secretvm-quickstart). Hosted alternatives: [Docker](/providers/full/proxy-router-docker), [Railway](/providers/full/proxy-router-railway) ([video](https://youtu.be/-z-EPK11qmM)), [AWS EC2](/providers/full/aws), or [Akash](/providers/full/proxy-router-akash).
 
 ## Assumptions
 


### PR DESCRIPTION
## What

Adds the public Morpheus Intern walkthrough as a first-class provider resource:

- **Video:** https://youtu.be/-z-EPK11qmM — *How to Become a Morpheus AI Provider on Railway*
- **New page:** `docs/providers/full/proxy-router-railway.mdx` (same GHCR image as Docker)
- Linked from provider checklist, full P-Node quickstart, Docker page, README quickstart table, `AGENTS.md`

## Why

The walkthrough is already live. Without a nodedocs slug, GitHub search and GitBook have nowhere canonical to point. Railway is the hosted GHCR path; Docker stays the reference for env/image.

## Ask

- Maintainers: merge to `dev` so it promotes with the rest of docs (`dev` → `test` → `main` / nodedocs.mor.org).
- **@anton** (GitBook owner): please add the same video + Railway page on gitbook.mor.org once this lands, so Morphy/GitBook and nodedocs do not diverge.

## Checklist

- [x] PR base is `dev`
- [x] No contract addresses invented (Docker page already holds the live ones)
- [x] Video is public on `@MorpheusIntern`