### PR TITLE
fix(ui): show agent loading and empty states

### DIFF
--- a/ui-desktop/src/renderer/src/components/agents/Agents.styles.ts
+++ b/ui-desktop/src/renderer/src/components/agents/Agents.styles.ts
@@ -18,6 +18,17 @@ export const AgentList = styled.div`
   padding-bottom: 2rem;
 `;
 
+export const ListStatus = styled.div`
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 1.2rem;
+  line-height: 1.5;
+  text-align: center;
+`;
+
 export const Button = styled(BtnAccent)`
   height: 3em;
   padding: 0 0.7em;

--- a/ui-desktop/src/renderer/src/components/agents/Agents.tsx
+++ b/ui-desktop/src/renderer/src/components/agents/Agents.tsx
@@ -14,6 +14,7 @@ import {
   TransactionList,
   TransactionRow,
   ScrollContainer,
+  ListStatus,
 } from '@renderer/components/agents/Agents.styles';
 import { AgentRowComp } from '@renderer/components/agents/AgentRow';
 import { AllowanceRowComp } from '@renderer/components/agents/AllowanceRow';
@@ -28,6 +29,8 @@ const Agents = (props: ContainerProps & MappedProps) => {
     handleApproveAccess,
     handleApproveAllowance,
     handleDeleteAgent,
+    isLoading,
+    loadError,
   } = props;
 
   return (
@@ -39,8 +42,15 @@ const Agents = (props: ContainerProps & MappedProps) => {
     >
       <LayoutHeader title="Agents" />
       <ScrollContainer>
+        {!isLoading && loadError && (
+          <ListStatus role="alert">{loadError}</ListStatus>
+        )}
         <SubHeader>Access requests</SubHeader>
         <AgentList>
+          {isLoading && <ListStatus>Loading access requests…</ListStatus>}
+          {!isLoading && !loadError && pendingAgents.length === 0 && (
+            <ListStatus>No pending access requests.</ListStatus>
+          )}
           {pendingAgents.map((agent) => (
             <AgentRowComp
               key={agent.username}
@@ -67,6 +77,10 @@ const Agents = (props: ContainerProps & MappedProps) => {
         </AgentList>
         <SubHeader>Allowance requests</SubHeader>
         <AgentList>
+          {isLoading && <ListStatus>Loading allowance requests…</ListStatus>}
+          {!isLoading && !loadError && allowanceRequests.length === 0 && (
+            <ListStatus>No pending allowance requests.</ListStatus>
+          )}
           {allowanceRequests.map((agent) => (
             <AllowanceRowComp
               key={`${agent.username}-${agent.token}`}
@@ -97,6 +111,10 @@ const Agents = (props: ContainerProps & MappedProps) => {
         </AgentList>
         <SubHeader>All Agents</SubHeader>
         <AgentList>
+          {isLoading && <ListStatus>Loading agents…</ListStatus>}
+          {!isLoading && !loadError && activeAgents.length === 0 && (
+            <ListStatus>No agents have been approved yet.</ListStatus>
+          )}
           {activeAgents.map((agent) => (
             <AgentRowComp
               key={agent.username}

--- a/ui-desktop/src/renderer/src/store/hocs/withAgentsState.tsx
+++ b/ui-desktop/src/renderer/src/store/hocs/withAgentsState.tsx
@@ -14,6 +14,8 @@ export interface ContainerProps {
   pendingAgents: AgentUser[];
   activeAgents: AgentUser[];
   allowanceRequests: AgentAllowanceRequest[];
+  isLoading: boolean;
+  loadError: string | null;
   txModal: TxModal;
   setTxModal: (txModal: TxModal) => void;
   handleApproveAccess: (agent: AgentUser, approve: boolean) => Promise<void>;
@@ -63,6 +65,8 @@ const withAgentsState = (WrappedComponent: ComponentType<any>) => {
     const [allowanceRequests, setAllowanceRequests] = useState<
       AgentAllowanceRequest[]
     >([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [loadError, setLoadError] = useState<string | null>(null);
     const [refresh, setRefresh] = useState(0);
     const context = useContext(ToastsContext);
 
@@ -95,34 +99,46 @@ const withAgentsState = (WrappedComponent: ComponentType<any>) => {
     }
 
     useEffect(() => {
-      fetchPageData();
+      void fetchPageData();
     }, [refresh]);
 
     async function fetchPageData() {
-      const pendingAgentRequests = await props.client.getAgentUsers();
-      if (!pendingAgentRequests) {
-        console.error('Failed to fetch pending agent requests');
-        return;
-      }
-      let pendingAgents: AgentUser[] = [];
-      let activeAgents: AgentUser[] = [];
+      setIsLoading(true);
+      setLoadError(null);
 
-      for (const agent of pendingAgentRequests.agents) {
-        if (agent.isConfirmed) {
-          activeAgents.push(agent);
-        } else {
-          pendingAgents.push(agent);
+      try {
+        const [agentUsersResponse, allowanceRequestsResponse] =
+          await Promise.all([
+            props.client.getAgentUsers(),
+            props.client.getAgentAllowanceRequests(),
+          ]);
+
+        if (!agentUsersResponse || !allowanceRequestsResponse) {
+          throw new Error('One or more agent API requests failed');
         }
-      }
-      setPendingAgents(pendingAgents);
-      setActiveAgents(activeAgents);
 
-      const allowanceRequests = await props.client.getAgentAllowanceRequests();
-      if (!allowanceRequests) {
-        console.error('Failed to fetch allowance requests');
-        return;
+        const nextPendingAgents: AgentUser[] = [];
+        const nextActiveAgents: AgentUser[] = [];
+
+        for (const agent of agentUsersResponse.agents) {
+          if (agent.isConfirmed) {
+            nextActiveAgents.push(agent);
+          } else {
+            nextPendingAgents.push(agent);
+          }
+        }
+
+        setPendingAgents(nextPendingAgents);
+        setActiveAgents(nextActiveAgents);
+        setAllowanceRequests(allowanceRequestsResponse.requests);
+      } catch (error) {
+        console.error('Failed to fetch agent data', error);
+        setLoadError(
+          'Unable to load agent data. Check that the proxy router is running and try again.',
+        );
+      } finally {
+        setIsLoading(false);
       }
-      setAllowanceRequests(allowanceRequests.requests);
     }
 
     async function handleApproveAccess(agent: AgentUser, approve: boolean) {
@@ -173,6 +189,8 @@ const withAgentsState = (WrappedComponent: ComponentType<any>) => {
         pendingAgents={pendingAgents}
         activeAgents={activeAgents}
         allowanceRequests={allowanceRequests}
+        isLoading={isLoading}
+        loadError={loadError}
         txModal={txModal}
         setTxModal={setTxModal}
         handleApproveAccess={handleApproveAccess}


### PR DESCRIPTION
## Summary
- show explicit loading states while agent and allowance data is fetched
- show clear empty states for access requests, allowance requests, and approved agents
- surface proxy-router fetch failures instead of leaving the page blank

Fixes #856

## Base branch
- [x] This PR targets **`dev`** (required for feature/docs/fix PRs)
- [ ] This is a **maintainer promote** into `test` or `main` (skip the line above)

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Prettier check for all three changed files

## Notes for reviewers
The full Electron production build passes. The repository's current ESLint config fails before linting any files because `.eslintrc.cjs` contains ESM `export default`; no ESLint config changes are included here.