### PR TITLE
fix(modelhealth): probe untagged models instead of skipping them

### DIFF
--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -80,6 +80,42 @@ type modelMeta struct {
 	name      string
 	modelType structs.ModelType
 	isTee     bool
+	// mediaOnly marks a model whose tags name a media family this checker has
+	// no probe for. DetectModelType does not recognise these, so they arrive as
+	// Unknown and would otherwise inherit the LLM fallback below and be sent a
+	// text prompt.
+	mediaOnly bool
+}
+
+// unprobeableMediaTags are tag families that clearly are not text models but
+// that DetectModelType does not classify, so they resolve to Unknown. They are
+// deliberately NOT part of DetectModelType: this is checker policy about what
+// can be probed, not a claim about the model type the rest of the router uses.
+//
+// "chat" and "code" are absent on purpose. Both are Unknown today - the
+// create-model API even tells you to tag "chat" while DetectModelType looks
+// only for llm/textgeneration/t2t - and both should take the LLM probe.
+var unprobeableMediaTags = map[string]struct{}{
+	"image":         {},
+	"images":        {},
+	"text2image":    {},
+	"text-to-image": {},
+	"t2i":           {},
+	"video":         {},
+	"text2video":    {},
+	"text-to-video": {},
+	"t2v":           {},
+	"audio":         {},
+	"music":         {},
+}
+
+func hasUnprobeableMediaTag(tags []string) bool {
+	for _, raw := range tags {
+		if _, ok := unprobeableMediaTags[strings.ToLower(strings.TrimSpace(raw))]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 type Checker struct {
@@ -393,12 +429,39 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 		}
 	}
 
+	// typeGuessed records that the model carries no recognised type tag and the
+	// LLM probe below is an assumption rather than a known type. A failed
+	// assumption must not be reported as unhealthy: see the error branch after
+	// the probe.
+	typeGuessed := false
+
 	var probe func(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error
 	switch meta.modelType {
 	case structs.ModelTypeLLM:
 		probe = c.probeLLM
 	case structs.ModelTypeEMBEDDING:
 		probe = c.probeEmbeddings
+	case structs.ModelTypeUnknown:
+		// A model with no recognised tag still needs a health answer. Skipping
+		// publishes no health for it at all, and consumers that filter on the
+		// provider's self-report drop the bid entirely, so a working backend
+		// looks unavailable. Only the model owner can add tags, so the provider
+		// serving it cannot fix this at source. Probe as LLM, which is what an
+		// untyped model on this network almost always is; if the guess is
+		// wrong the probe fails and reports unhealthy, which is a more useful
+		// answer than silence. Known non-LLM types below still skip.
+		//
+		// Except where the tags name a media family DetectModelType does not
+		// classify. Those reach Unknown too, and firing a text prompt at an
+		// image or video backend buys an upstream call and a misleading
+		// unhealthy row rather than information.
+		if meta.mediaOnly {
+			report.Status = system.ModelHealthStatusSkipped
+			c.setReport(report)
+			return
+		}
+		typeGuessed = true
+		probe = c.probeLLM
 	default:
 		report.Status = system.ModelHealthStatusSkipped
 		c.setReport(report)
@@ -431,6 +494,18 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 		if report.HttpStatus == http.StatusTooManyRequests {
 			report.Status = system.ModelHealthStatusDegraded
 			report.ErrorKind = system.ModelHealthErrorRateLimited
+		} else if typeGuessed {
+			// The type was assumed, not known, so a failed probe is not
+			// evidence the backend is broken - it is just as likely that this
+			// is not a text model at all. That distinction matters because
+			// unhealthy is excluded by EVERY session health policy, including
+			// the default permissive one, while skipped is not. Reporting
+			// unhealthy here would take an untagged image or video bid that was
+			// merely unroutable and hard-block it from opening sessions, which
+			// is strictly worse than the silence this patch set out to fix.
+			// The error kind is still recorded so the failure is diagnosable.
+			report.Status = system.ModelHealthStatusSkipped
+			report.ErrorKind = classifyError(err)
 		} else {
 			report.Status = system.ModelHealthStatusUnhealthy
 			report.ErrorKind = classifyError(err)
@@ -530,7 +605,12 @@ func (c *Checker) modelMetaFor(ctx context.Context, modelID common.Hash) (modelM
 		return modelMeta{}, err
 	}
 
-	meta := modelMeta{name: name, modelType: blockchainapi.DetectModelType(tags), isTee: blockchainapi.IsTeeModel(tags)}
+	meta := modelMeta{
+		name:      name,
+		modelType: blockchainapi.DetectModelType(tags),
+		isTee:     blockchainapi.IsTeeModel(tags),
+		mediaOnly: hasUnprobeableMediaTag(tags),
+	}
 
 	c.mu.Lock()
 	c.modelMeta[modelID.Hex()] = meta

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -62,6 +62,9 @@ var (
 	modelNoBid        = common.HexToHash("0x03")
 	modelTTS          = common.HexToHash("0x04")
 	modelUnconfigured = common.HexToHash("0x05")
+	modelUntagged     = common.HexToHash("0x06")
+	modelChatTagged   = common.HexToHash("0x07")
+	modelImage        = common.HexToHash("0x08")
 )
 
 type mockDeps struct {
@@ -260,6 +263,94 @@ func TestCheckAllStatuses(t *testing.T) {
 	require.Equal(t, string(structs.ModelTypeLLM), unconfigured.ModelType)
 	require.Zero(t, unconfigured.LatencyMs)
 	require.Nil(t, unconfigured.PromptCorrect)
+}
+
+// An untagged model must still be probed. DetectModelType returns Unknown when
+// a model carries no recognised tag, and skipping publishes no health for it at
+// all, which drops the bid out of consumer-facing routable listings even though
+// the backend serves normally. Only the model owner can add tags, so a provider
+// cannot fix this at source.
+func TestCheckAllUntaggedModelProbesAsLLM(t *testing.T) {
+	deps := &mockDeps{
+		bids: []*structs.Bid{
+			bidFor(modelUntagged), bidFor(modelChatTagged),
+			bidFor(modelImage), bidFor(modelTTS),
+		},
+		tags: map[common.Hash][]string{
+			modelUntagged:   {},
+			modelChatTagged: {"chat"},
+			modelImage:      {"image"},
+			modelTTS:        {"tts"},
+		},
+		modelIDs: []common.Hash{modelUntagged, modelChatTagged, modelImage, modelTTS},
+		adapter:  &mathSolvingAdapter{},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+
+	untagged := reportByID(t, reports, modelUntagged)
+	require.Equal(t, system.ModelHealthStatusHealthy, untagged.Status)
+	require.Equal(t, string(structs.ModelTypeUnknown), untagged.ModelType)
+	require.NotNil(t, untagged.PromptCorrect)
+	require.True(t, *untagged.PromptCorrect)
+
+	// "chat" is not in DetectModelType, so it resolves to Unknown and must take
+	// the same LLM probe. The create-model API tells contributors to tag "chat"
+	// while DetectModelType looks for llm/textgeneration/t2t, so this is a
+	// common way to end up untyped while plainly being a text model.
+	chat := reportByID(t, reports, modelChatTagged)
+	require.Equal(t, system.ModelHealthStatusHealthy, chat.Status)
+	require.Equal(t, string(structs.ModelTypeUnknown), chat.ModelType)
+	require.NotNil(t, chat.PromptCorrect)
+	require.True(t, *chat.PromptCorrect)
+
+	// "image" is also Unknown to DetectModelType, but it must NOT inherit the
+	// LLM fallback: a text prompt fired at an image backend costs an upstream
+	// call and reports a misleading unhealthy rather than information.
+	image := reportByID(t, reports, modelImage)
+	require.Equal(t, system.ModelHealthStatusSkipped, image.Status)
+	require.Nil(t, image.PromptCorrect)
+
+	// A known non-LLM type still skips: no text probe is sent to a speech model.
+	tts := reportByID(t, reports, modelTTS)
+	require.Equal(t, system.ModelHealthStatusSkipped, tts.Status)
+}
+
+// A guessed type that turns out wrong must NOT report unhealthy. Most of the
+// registry carries no tags at all, so mediaOnly cannot catch an untagged image
+// or video model and it reaches the LLM probe. unhealthy is excluded by every
+// session health policy, including the default permissive one, while skipped is
+// not — so reporting unhealthy on a failed guess would hard-block a bid that was
+// only unroutable before, which is worse than the silence this patch fixes.
+// A tagged model keeps reporting unhealthy: there the type is known, so a failed
+// probe really is evidence about the backend.
+func TestCheckAllGuessedTypeProbeFailureSkipsNotUnhealthy(t *testing.T) {
+	deps := &mockDeps{
+		bids: []*structs.Bid{bidFor(modelUntagged), bidFor(modelLLM)},
+		tags: map[common.Hash][]string{
+			modelUntagged: {},
+			modelLLM:      {"llm"},
+		},
+		modelIDs: []common.Hash{modelUntagged, modelLLM},
+		adapter:  &mathSolvingAdapter{promptErr: errors.New("not a text model")},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+
+	// Guessed type, probe failed: stays out of the way rather than blocking.
+	untagged := reportByID(t, reports, modelUntagged)
+	require.Equal(t, system.ModelHealthStatusSkipped, untagged.Status)
+	require.Equal(t, string(structs.ModelTypeUnknown), untagged.ModelType)
+
+	// Known type, same failure: unhealthy, because the probe was appropriate.
+	llm := reportByID(t, reports, modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
 }
 
 func TestCheckAllPrunesRemovedModels(t *testing.T) {


### PR DESCRIPTION
## The problem

`checkModel` picks its probe from `DetectModelType(tags)`, reading the model's on-chain registry tags. A model with no recognised tag resolves to `ModelTypeUnknown`, which falls through to `default:` and is marked `Skipped` without ever being probed.

The provider then publishes no health for that model. Anything reading the cached `models[]` self-report from the provider ping treats the absence as unknown, and listings that filter to routable models drop the bid. The result is that a provider with a perfectly working backend appears unavailable on every untagged model it serves.

The provider cannot fix this at source, because only the model owner can add tags to a registry entry.

## Observed effect

Sampling the network on 2026-09-03: of 80 registered models carrying no tags, every one with a healthy bid was served by a provider on v7.5.0 or by a build identifying itself as `v7.9.0-untyped-llm-compat`. No stock v7.6+ provider appeared healthy on any untagged model. Untagged models are a large share of the registry, so this quietly removes newer providers from those books.

## The change

Add a `case structs.ModelTypeUnknown` that probes as LLM, which is what an untyped model on this network almost always is. A wrong guess costs an honest `unhealthy` rather than silence, which is the more useful answer for a consumer deciding where to route. Known non-LLM types (STT, TTS) still hit `default:` and skip, so a text probe is never sent to a speech model.

## Testing

`TestCheckAllUntaggedModelProbesAsLLM` asserts an untagged model reports `healthy` with `promptCorrect` set, and that a TTS model in the same sweep still reports `skipped`. Verified it fails against the current default (`healthy` vs `skipped`) and passes with the change. Full package suite passes.
