### PR TITLE
fix(proxy-router): do not ERROR on unconfigured IPFS default (#872)

### DIFF
--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -242,10 +242,9 @@ func (cfg *Config) SetDefaults() {
 		cfg.Proxy.SessionHealthPolicy = "permissive"
 	}
 
-	// IPFS
-	if cfg.IPFS.Address == "" {
-		cfg.IPFS.Address = "localhost:5001"
-	}
+	// IPFS: leave Address empty when unset. A host:port default is not a
+	// multiaddr and made NewIpfsManager log ERROR on every headless boot (#872).
+	// Operators who run Kubo should set IPFS_MULTADDR (e.g. /ip4/127.0.0.1/tcp/5001).
 
 	// TEE
 	if cfg.TEE.PortalURL == "" {

--- a/proxy-router/internal/proxyapi/ipfs_manager.go
+++ b/proxy-router/internal/proxyapi/ipfs_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
@@ -36,9 +37,13 @@ type ProgressCallback func(downloaded, total int64) error
 
 // NewIpfsManager connects to the local Kubo (IPFS) node using the RPC client.
 func NewIpfsManager(ipfsAddress string, log lib.ILogger) *IpfsManager {
+	if strings.TrimSpace(ipfsAddress) == "" {
+		return NewIpfsManagerDisabled(log)
+	}
+
 	ma, err := multiaddr.NewMultiaddr(ipfsAddress)
 	if err != nil {
-		log.Error("invalid IPFSmultiaddr:", ipfsAddress, err)
+		log.Warn("invalid IPFSmultiaddr:", ipfsAddress, err)
 		return NewIpfsManagerDisabled(log)
 	}
 


### PR DESCRIPTION
## Summary

Fixes #872.

Stock headless proxy-router boots (no `IPFS_*` env) defaulted `IPFS_MULTADDR` to `localhost:5001`. That is not a multiaddr, so `NewIpfsManager` logged **ERROR + stack** via `multiaddr.NewMultiaddr`, then disabled IPFS anyway.

This does **not** “add a leading `/`” and does **not** invent a Kubo listen address. Headless C-Node typically has no Kubo daemon; a syntactically valid `/ip4/127.0.0.1/tcp/5001` would only hide the parse error and could log “connected to IPFS” with nothing listening.

## Changes

1. `proxy-router/internal/config/config.go` — stop defaulting `IPFS.Address` to `localhost:5001`. Unset means unconfigured.
2. `proxy-router/internal/proxyapi/ipfs_manager.go` — empty address → disabled (existing `NewIpfsManagerDisabled` path). Invalid multiaddr → **Warn**, no ERROR stack, then disabled.

Operators who run Kubo still set `IPFS_MULTADDR` to a real multiaddr, e.g. `/ip4/127.0.0.1/tcp/5001`. `IPFS_DISABLED=true` is unchanged.

## Test plan

- [ ] Boot image with no `IPFS_*` vars: no ERROR/stack for `localhost:5001`; IPFS stays disabled.
- [ ] `IPFS_DISABLED=true`: still disabled.
- [ ] `IPFS_MULTADDR=/ip4/127.0.0.1/tcp/5001` with Kubo on 5001: still connects.
- [ ] Garbage `IPFS_MULTADDR`: Warn, then disabled.

