### PR TITLE
promote: untagged model-health probe to test (#866)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2263,8 +2263,13 @@ jobs:
     # FAILED; its automation loop expires OPEN-past-expires_at), but this job clears
     # the whole batch immediately so users don't eat up to ~30 min of intermittent
     # "provider not found" retries. The Lambda is safe/idempotent (summary-first,
-    # refuses a future cutoff, guarded by SWEEP_MAX_ROWS). See Morpheus-Infra
+    # refuses a *future* cutoff, guarded by SWEEP_MAX_ROWS). See Morpheus-Infra
     # 02-morpheus_c_node/.terragrunt/06_routed_sessions_sweep.tf.
+    #
+    # Invoke immediately once Deploy-to-Morpheus-C-Node succeeded (rehydration hold
+    # + health already ran). Pass cutoff_utc = PRIMARY updatedAt — already in the
+    # past. Do not pad +90s/+120s and sleep; that is what aborted v7.10.0 with
+    # "cutoff is in the future" after the node was confirmed up.
     #
     # Runs only after a successful C-Node deploy; tolerates skipped P-Node jobs the
     # same way Deploy-to-Morpheus-C-Node does. Never fails the pipeline on a sweep
@@ -2303,94 +2308,71 @@ jobs:
           FUNCTION_NAME="${ENV}-routed-sessions-sweep"
           CLUSTER_NAME="ecs-${ENV}-morpheus-engine"
           SERVICE_NAME="svc-${ENV}-router"
-          # Must match Lambda DEFAULT_REHYDRATION_SECS / DEFAULT_SAFETY_SECS
-          # (02-morpheus_c_node/.terragrunt/06_routed_sessions_sweep.tf).
-          REHYDRATION_SECS=90
-          SAFETY_SECS=120
-          SKEW_BUFFER_SECS=15
 
-          # deploy_cutoff mode (default): the Lambda derives cutoff from the
-          # C-Node PRIMARY deployment updatedAt + rehydration + safety, then
-          # closes OPEN rows older than that. release_tag only annotates
-          # error_reason.
-          PAYLOAD="{\"release_tag\":\"${BUILDTAG}\"}"
-
-          # Proactive wait: the Lambda REFUSES a future cutoff (would close
-          # fresh sessions). Invoking immediately after C-Node settle almost
-          # always 400s for ~updatedAt+210s, and the old 10×30s retry budget
-          # was barely enough — leaving zombies OPEN long enough to reopen/
-          # failover-storm MOR. Sleep until the same cutoff the Lambda will
-          # derive, then invoke (small retry loop only for clock skew).
+          # cutoff_utc = PRIMARY updatedAt (naive UTC). Already in the past:
+          # this job only runs after Deploy-to-Morpheus-C-Node finished the
+          # rehydration hold + health check. Do not pad into the future.
           echo "🔎 Resolving C-Node PRIMARY updatedAt from ${CLUSTER_NAME}/${SERVICE_NAME}..."
           UPDATED_AT=$(aws ecs describe-services \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
             --query 'services[0].deployments[?status==`PRIMARY`]|[0].updatedAt' \
             --output text)
-          if [ -z "$UPDATED_AT" ] || [ "$UPDATED_AT" = "None" ]; then
-            echo "⚠️ Could not resolve PRIMARY updatedAt; falling back to fixed ${REHYDRATION_SECS}+${SAFETY_SECS}s wait."
-            sleep $((REHYDRATION_SECS + SAFETY_SECS + SKEW_BUFFER_SECS))
+
+          CUTOFF_UTC=""
+          if [ -n "$UPDATED_AT" ] && [ "$UPDATED_AT" != "None" ]; then
+            CUTOFF_UTC=$(python3 -c '
+import sys
+from datetime import datetime, timezone
+raw = sys.argv[1].strip().replace("Z", "+00:00")
+dt = datetime.fromisoformat(raw)
+if dt.tzinfo is None:
+    dt = dt.replace(tzinfo=timezone.utc)
+print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
+' "$UPDATED_AT")
+            echo "📌 PRIMARY updatedAt: ${UPDATED_AT} → cutoff_utc=${CUTOFF_UTC} UTC (invoke immediately)"
           else
-            echo "📌 PRIMARY updatedAt: ${UPDATED_AT}"
-            UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s)
-            CUTOFF_EPOCH=$((UPDATED_EPOCH + REHYDRATION_SECS + SAFETY_SECS + SKEW_BUFFER_SECS))
-            NOW_EPOCH=$(date +%s)
-            WAIT_SECS=$((CUTOFF_EPOCH - NOW_EPOCH))
-            if [ "$WAIT_SECS" -gt 0 ]; then
-              echo "⏳ Waiting ${WAIT_SECS}s for sweep cutoff (updatedAt + ${REHYDRATION_SECS}s + ${SAFETY_SECS}s + ${SKEW_BUFFER_SECS}s skew)..."
-              sleep "$WAIT_SECS"
-            else
-              echo "✅ Cutoff already in the past (${WAIT_SECS}s); invoking immediately."
-            fi
+            echo "⚠️ Could not resolve PRIMARY updatedAt; Lambda will derive from ECS."
           fi
 
-          MAX_ATTEMPTS=5
-          SLEEP_SECS=20
+          PAYLOAD=$(python3 -c '
+import json, sys
+tag = sys.argv[1]
+cutoff = sys.argv[2] if len(sys.argv) > 2 else ""
+payload = {"release_tag": tag}
+if cutoff:
+    payload["cutoff_utc"] = cutoff
+print(json.dumps(payload))
+' "$BUILDTAG" "$CUTOFF_UTC")
+
           STATUS=""
           BODY=""
           FUNCTION_ERROR=""
-          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            echo "🧹 [attempt ${attempt}/${MAX_ATTEMPTS}] Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
-            set +e
-            INVOKE_META=$(aws lambda invoke \
-              --function-name "$FUNCTION_NAME" \
-              --cli-binary-format raw-in-base64-out \
-              --payload "$PAYLOAD" \
-              /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
-            INVOKE_RC=$?
-            set -e
+          echo "🧹 Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
+          set +e
+          INVOKE_META=$(aws lambda invoke \
+            --function-name "$FUNCTION_NAME" \
+            --cli-binary-format raw-in-base64-out \
+            --payload "$PAYLOAD" \
+            /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
+          INVOKE_RC=$?
+          set -e
 
-            if [ $INVOKE_RC -ne 0 ]; then
-              echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
-              cat /tmp/sweep_err.txt || true
-              echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
-              exit 0
-            fi
+          if [ $INVOKE_RC -ne 0 ]; then
+            echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
+            cat /tmp/sweep_err.txt || true
+            echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
+            exit 0
+          fi
 
-            echo "📡 Invoke metadata: $INVOKE_META"
-            FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
-            RESPONSE=$(cat /tmp/sweep_out.json)
-            echo "📦 Lambda response: $RESPONSE"
+          echo "📡 Invoke metadata: $INVOKE_META"
+          FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
+          RESPONSE=$(cat /tmp/sweep_out.json)
+          echo "📦 Lambda response: $RESPONSE"
 
-            # The handler returns {"statusCode": N, "body": "<json string>"}.
-            STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
-            BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
-
-            # An unhandled Lambda error has no statusCode — terminal, don't retry.
-            if [ -n "$FUNCTION_ERROR" ]; then
-              break
-            fi
-
-            # Retry ONLY residual "future cutoff" 400 (clock skew / ECS lag).
-            if [ "$STATUS" = "400" ] && echo "$BODY" | grep -qi "in the future"; then
-              if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-                echo "⏳ Cutoff not reached yet; sleeping ${SLEEP_SECS}s before retry."
-                sleep "$SLEEP_SECS"
-                continue
-              fi
-            fi
-            break
-          done
+          # The handler returns {"statusCode": N, "body": "<json string>"}.
+          STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
+          BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
 
           {
             echo "### 🧹 Routed-sessions zombie sweep"
@@ -2398,6 +2380,7 @@ jobs:
             echo "- **Function:** \`${FUNCTION_NAME}\`"
             echo "- **Release tag:** \`${BUILDTAG}\`"
             echo "- **PRIMARY updatedAt:** \`${UPDATED_AT:-unknown}\`"
+            echo "- **cutoff_utc:** \`${CUTOFF_UTC:-lambda-derived}\`"
             echo "- **Handler statusCode:** \`${STATUS:-unknown}\`"
             if [ -n "$BODY" ]; then
               echo ""
@@ -2416,7 +2399,7 @@ jobs:
           if [ "$STATUS" = "200" ]; then
             echo "✅ Sweep completed."
           else
-            echo "⚠️ Sweep returned non-200 statusCode '${STATUS}' (e.g. future-cutoff or > SWEEP_MAX_ROWS guard)."
+            echo "⚠️ Sweep returned non-200 statusCode '${STATUS}' (e.g. > SWEEP_MAX_ROWS guard)."
             echo "ℹ️ Review the response above and run the runbook sweep manually if needed. Not failing the pipeline."
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2321,29 +2321,16 @@ jobs:
 
           CUTOFF_UTC=""
           if [ -n "$UPDATED_AT" ] && [ "$UPDATED_AT" != "None" ]; then
-            CUTOFF_UTC=$(python3 -c '
-import sys
-from datetime import datetime, timezone
-raw = sys.argv[1].strip().replace("Z", "+00:00")
-dt = datetime.fromisoformat(raw)
-if dt.tzinfo is None:
-    dt = dt.replace(tzinfo=timezone.utc)
-print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
-' "$UPDATED_AT")
+            # One-liners: a column-0 python body inside `run: |` terminates the
+            # YAML block (GitHub: "Invalid workflow file") and the whole CI-CD
+            # graph matches zero jobs. Keep this indented.
+            CUTOFF_UTC=$(python3 -c 'import sys; from datetime import datetime, timezone; raw = sys.argv[1].strip().replace("Z", "+00:00"); dt = datetime.fromisoformat(raw); dt = dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt; print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))' "$UPDATED_AT")
             echo "📌 PRIMARY updatedAt: ${UPDATED_AT} → cutoff_utc=${CUTOFF_UTC} UTC (invoke immediately)"
           else
             echo "⚠️ Could not resolve PRIMARY updatedAt; Lambda will derive from ECS."
           fi
 
-          PAYLOAD=$(python3 -c '
-import json, sys
-tag = sys.argv[1]
-cutoff = sys.argv[2] if len(sys.argv) > 2 else ""
-payload = {"release_tag": tag}
-if cutoff:
-    payload["cutoff_utc"] = cutoff
-print(json.dumps(payload))
-' "$BUILDTAG" "$CUTOFF_UTC")
+          PAYLOAD=$(python3 -c 'import json, sys; tag = sys.argv[1]; cutoff = sys.argv[2] if len(sys.argv) > 2 else ""; payload = {"release_tag": tag}; payload.update({"cutoff_utc": cutoff} if cutoff else {}); print(json.dumps(payload))' "$BUILDTAG" "$CUTOFF_UTC")
 
           STATUS=""
           BODY=""

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -80,6 +80,42 @@ type modelMeta struct {
 	name      string
 	modelType structs.ModelType
 	isTee     bool
+	// mediaOnly marks a model whose tags name a media family this checker has
+	// no probe for. DetectModelType does not recognise these, so they arrive as
+	// Unknown and would otherwise inherit the LLM fallback below and be sent a
+	// text prompt.
+	mediaOnly bool
+}
+
+// unprobeableMediaTags are tag families that clearly are not text models but
+// that DetectModelType does not classify, so they resolve to Unknown. They are
+// deliberately NOT part of DetectModelType: this is checker policy about what
+// can be probed, not a claim about the model type the rest of the router uses.
+//
+// "chat" and "code" are absent on purpose. Both are Unknown today - the
+// create-model API even tells you to tag "chat" while DetectModelType looks
+// only for llm/textgeneration/t2t - and both should take the LLM probe.
+var unprobeableMediaTags = map[string]struct{}{
+	"image":         {},
+	"images":        {},
+	"text2image":    {},
+	"text-to-image": {},
+	"t2i":           {},
+	"video":         {},
+	"text2video":    {},
+	"text-to-video": {},
+	"t2v":           {},
+	"audio":         {},
+	"music":         {},
+}
+
+func hasUnprobeableMediaTag(tags []string) bool {
+	for _, raw := range tags {
+		if _, ok := unprobeableMediaTags[strings.ToLower(strings.TrimSpace(raw))]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 type Checker struct {
@@ -393,12 +429,39 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 		}
 	}
 
+	// typeGuessed records that the model carries no recognised type tag and the
+	// LLM probe below is an assumption rather than a known type. A failed
+	// assumption must not be reported as unhealthy: see the error branch after
+	// the probe.
+	typeGuessed := false
+
 	var probe func(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error
 	switch meta.modelType {
 	case structs.ModelTypeLLM:
 		probe = c.probeLLM
 	case structs.ModelTypeEMBEDDING:
 		probe = c.probeEmbeddings
+	case structs.ModelTypeUnknown:
+		// A model with no recognised tag still needs a health answer. Skipping
+		// publishes no health for it at all, and consumers that filter on the
+		// provider's self-report drop the bid entirely, so a working backend
+		// looks unavailable. Only the model owner can add tags, so the provider
+		// serving it cannot fix this at source. Probe as LLM, which is what an
+		// untyped model on this network almost always is; if the guess is
+		// wrong the probe fails and reports unhealthy, which is a more useful
+		// answer than silence. Known non-LLM types below still skip.
+		//
+		// Except where the tags name a media family DetectModelType does not
+		// classify. Those reach Unknown too, and firing a text prompt at an
+		// image or video backend buys an upstream call and a misleading
+		// unhealthy row rather than information.
+		if meta.mediaOnly {
+			report.Status = system.ModelHealthStatusSkipped
+			c.setReport(report)
+			return
+		}
+		typeGuessed = true
+		probe = c.probeLLM
 	default:
 		report.Status = system.ModelHealthStatusSkipped
 		c.setReport(report)
@@ -431,6 +494,18 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 		if report.HttpStatus == http.StatusTooManyRequests {
 			report.Status = system.ModelHealthStatusDegraded
 			report.ErrorKind = system.ModelHealthErrorRateLimited
+		} else if typeGuessed {
+			// The type was assumed, not known, so a failed probe is not
+			// evidence the backend is broken - it is just as likely that this
+			// is not a text model at all. That distinction matters because
+			// unhealthy is excluded by EVERY session health policy, including
+			// the default permissive one, while skipped is not. Reporting
+			// unhealthy here would take an untagged image or video bid that was
+			// merely unroutable and hard-block it from opening sessions, which
+			// is strictly worse than the silence this patch set out to fix.
+			// The error kind is still recorded so the failure is diagnosable.
+			report.Status = system.ModelHealthStatusSkipped
+			report.ErrorKind = classifyError(err)
 		} else {
 			report.Status = system.ModelHealthStatusUnhealthy
 			report.ErrorKind = classifyError(err)
@@ -530,7 +605,12 @@ func (c *Checker) modelMetaFor(ctx context.Context, modelID common.Hash) (modelM
 		return modelMeta{}, err
 	}
 
-	meta := modelMeta{name: name, modelType: blockchainapi.DetectModelType(tags), isTee: blockchainapi.IsTeeModel(tags)}
+	meta := modelMeta{
+		name:      name,
+		modelType: blockchainapi.DetectModelType(tags),
+		isTee:     blockchainapi.IsTeeModel(tags),
+		mediaOnly: hasUnprobeableMediaTag(tags),
+	}
 
 	c.mu.Lock()
 	c.modelMeta[modelID.Hex()] = meta

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -62,6 +62,9 @@ var (
 	modelNoBid        = common.HexToHash("0x03")
 	modelTTS          = common.HexToHash("0x04")
 	modelUnconfigured = common.HexToHash("0x05")
+	modelUntagged     = common.HexToHash("0x06")
+	modelChatTagged   = common.HexToHash("0x07")
+	modelImage        = common.HexToHash("0x08")
 )
 
 type mockDeps struct {
@@ -260,6 +263,94 @@ func TestCheckAllStatuses(t *testing.T) {
 	require.Equal(t, string(structs.ModelTypeLLM), unconfigured.ModelType)
 	require.Zero(t, unconfigured.LatencyMs)
 	require.Nil(t, unconfigured.PromptCorrect)
+}
+
+// An untagged model must still be probed. DetectModelType returns Unknown when
+// a model carries no recognised tag, and skipping publishes no health for it at
+// all, which drops the bid out of consumer-facing routable listings even though
+// the backend serves normally. Only the model owner can add tags, so a provider
+// cannot fix this at source.
+func TestCheckAllUntaggedModelProbesAsLLM(t *testing.T) {
+	deps := &mockDeps{
+		bids: []*structs.Bid{
+			bidFor(modelUntagged), bidFor(modelChatTagged),
+			bidFor(modelImage), bidFor(modelTTS),
+		},
+		tags: map[common.Hash][]string{
+			modelUntagged:   {},
+			modelChatTagged: {"chat"},
+			modelImage:      {"image"},
+			modelTTS:        {"tts"},
+		},
+		modelIDs: []common.Hash{modelUntagged, modelChatTagged, modelImage, modelTTS},
+		adapter:  &mathSolvingAdapter{},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+
+	untagged := reportByID(t, reports, modelUntagged)
+	require.Equal(t, system.ModelHealthStatusHealthy, untagged.Status)
+	require.Equal(t, string(structs.ModelTypeUnknown), untagged.ModelType)
+	require.NotNil(t, untagged.PromptCorrect)
+	require.True(t, *untagged.PromptCorrect)
+
+	// "chat" is not in DetectModelType, so it resolves to Unknown and must take
+	// the same LLM probe. The create-model API tells contributors to tag "chat"
+	// while DetectModelType looks for llm/textgeneration/t2t, so this is a
+	// common way to end up untyped while plainly being a text model.
+	chat := reportByID(t, reports, modelChatTagged)
+	require.Equal(t, system.ModelHealthStatusHealthy, chat.Status)
+	require.Equal(t, string(structs.ModelTypeUnknown), chat.ModelType)
+	require.NotNil(t, chat.PromptCorrect)
+	require.True(t, *chat.PromptCorrect)
+
+	// "image" is also Unknown to DetectModelType, but it must NOT inherit the
+	// LLM fallback: a text prompt fired at an image backend costs an upstream
+	// call and reports a misleading unhealthy rather than information.
+	image := reportByID(t, reports, modelImage)
+	require.Equal(t, system.ModelHealthStatusSkipped, image.Status)
+	require.Nil(t, image.PromptCorrect)
+
+	// A known non-LLM type still skips: no text probe is sent to a speech model.
+	tts := reportByID(t, reports, modelTTS)
+	require.Equal(t, system.ModelHealthStatusSkipped, tts.Status)
+}
+
+// A guessed type that turns out wrong must NOT report unhealthy. Most of the
+// registry carries no tags at all, so mediaOnly cannot catch an untagged image
+// or video model and it reaches the LLM probe. unhealthy is excluded by every
+// session health policy, including the default permissive one, while skipped is
+// not — so reporting unhealthy on a failed guess would hard-block a bid that was
+// only unroutable before, which is worse than the silence this patch fixes.
+// A tagged model keeps reporting unhealthy: there the type is known, so a failed
+// probe really is evidence about the backend.
+func TestCheckAllGuessedTypeProbeFailureSkipsNotUnhealthy(t *testing.T) {
+	deps := &mockDeps{
+		bids: []*structs.Bid{bidFor(modelUntagged), bidFor(modelLLM)},
+		tags: map[common.Hash][]string{
+			modelUntagged: {},
+			modelLLM:      {"llm"},
+		},
+		modelIDs: []common.Hash{modelUntagged, modelLLM},
+		adapter:  &mathSolvingAdapter{promptErr: errors.New("not a text model")},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+
+	// Guessed type, probe failed: stays out of the way rather than blocking.
+	untagged := reportByID(t, reports, modelUntagged)
+	require.Equal(t, system.ModelHealthStatusSkipped, untagged.Status)
+	require.Equal(t, string(structs.ModelTypeUnknown), untagged.ModelType)
+
+	// Known type, same failure: unhealthy, because the probe was appropriate.
+	llm := reportByID(t, reports, modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
 }
 
 func TestCheckAllPrunesRemovedModels(t *testing.T) {


### PR DESCRIPTION
## Summary
- Promote [dev](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/tree/dev) → [test](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/tree/test) for **#866** (untagged models: probe as LLM; failed guess stays `skipped`; tagged `image`/`video`/`audio` skip).
- Also on this delta (already on `dev`, not yet on `test`): **#863** zombie `routed_sessions` sweep cutoff in `build.yml`.

`test` is ahead of `dev` on other promotes (Railway docs, etc.). File diff for this PR is three files: `checker.go`, `checker_test.go`, `build.yml`.

Push-to-`dev` CI-CD for #866 concluded `failure` with **zero jobs** (same pattern as #863 since ~Aug 25 — workflow starts, no job `if` matches / empty run). That is not a failed Docker smoke. Local confirmation: `go test ./internal/modelhealth/ -count=1` on `65d9acb` — ok.

Merge to `test` **does** run the real CI-CD (build/test + AWS DEV deploy).

## Test plan
- [ ] GitHub file diff is `modelhealth` + #863 `build.yml` only
- [ ] After merge, `test` CI-CD jobs actually run (not a zero-job red X)
- [ ] Staging C-Node / P-Node: untagged text models can self-report `healthy`; untagged non-text that fail the LLM probe stay `skipped` (still openable under permissive)
- [ ] Tagged LLM/embedding probe failures still `unhealthy`


Made with [Cursor](https://cursor.com)