### PR TITLE
fix(ci): parse build.yml after #863 column-0 python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2321,29 +2321,16 @@ jobs:
 
           CUTOFF_UTC=""
           if [ -n "$UPDATED_AT" ] && [ "$UPDATED_AT" != "None" ]; then
-            CUTOFF_UTC=$(python3 -c '
-import sys
-from datetime import datetime, timezone
-raw = sys.argv[1].strip().replace("Z", "+00:00")
-dt = datetime.fromisoformat(raw)
-if dt.tzinfo is None:
-    dt = dt.replace(tzinfo=timezone.utc)
-print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
-' "$UPDATED_AT")
+            # One-liners: a column-0 python body inside `run: |` terminates the
+            # YAML block (GitHub: "Invalid workflow file") and the whole CI-CD
+            # graph matches zero jobs. Keep this indented.
+            CUTOFF_UTC=$(python3 -c 'import sys; from datetime import datetime, timezone; raw = sys.argv[1].strip().replace("Z", "+00:00"); dt = datetime.fromisoformat(raw); dt = dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt; print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))' "$UPDATED_AT")
             echo "📌 PRIMARY updatedAt: ${UPDATED_AT} → cutoff_utc=${CUTOFF_UTC} UTC (invoke immediately)"
           else
             echo "⚠️ Could not resolve PRIMARY updatedAt; Lambda will derive from ECS."
           fi
 
-          PAYLOAD=$(python3 -c '
-import json, sys
-tag = sys.argv[1]
-cutoff = sys.argv[2] if len(sys.argv) > 2 else ""
-payload = {"release_tag": tag}
-if cutoff:
-    payload["cutoff_utc"] = cutoff
-print(json.dumps(payload))
-' "$BUILDTAG" "$CUTOFF_UTC")
+          PAYLOAD=$(python3 -c 'import json, sys; tag = sys.argv[1]; cutoff = sys.argv[2] if len(sys.argv) > 2 else ""; payload = {"release_tag": tag}; payload.update({"cutoff_utc": cutoff} if cutoff else {}); print(json.dumps(payload))' "$BUILDTAG" "$CUTOFF_UTC")
 
           STATUS=""
           BODY=""


### PR DESCRIPTION
## Summary
- `#863` left two `python3 -c` bodies at column 0 inside a `run: |` block. That ends the YAML literal, so GitHub reports `Invalid workflow file: .github/workflows/build.yml` and the CI-CD graph matches **zero jobs**.
- Every `dev` CI-CD run since 2026-08-25 has been that parse failure (including the `#866` merge). `test` / `main` are still green because `#863` never promoted.
- Collapse both snippets to indented one-liners (same cutoff + payload behavior). Do **not** merge promote #874 until this is on `dev`.

## Test plan
- [ ] PR does **not** show `Invalid workflow file` / empty CI-CD graph (pull_request is commented out; a syntax error is the only way CI-CD appears on a feature PR).
- [ ] After merge to `dev`, the push run shows a real job graph (Detect changed components, Go modules, tag, docker smoke) instead of an empty canvas.
- [ ] Zombie-sweep still skipped on `dev` (build-only). First real invoke is the next `test` promote, with `cutoff_utc` in the past.


Made with [Cursor](https://cursor.com)