### PR TITLE
docs: ALL/ACTIVE/GATEWAY catalog + v7.11 probe/IPFS/stake notes

### DIFF
--- a/.cursor/rules/morpheus.mdc
+++ b/.cursor/rules/morpheus.mdc
@@ -19,11 +19,11 @@ This repository has nuance that generic web knowledge gets wrong. **Before answe
 
 0. **Never confuse the proxy-router HTTP API (this repo) with the hosted Morpheus Inference API.** The proxy-router API is documented at `proxy-router/docs/swagger.yaml`. The hosted Morpheus Inference API at [apidocs.mor.org](https://apidocs.mor.org) (`https://api.mor.org/api/v1`) is a **separate product** for users who don't run a node — see [`docs/inference-api/overview.mdx`](../../docs/inference-api/overview.mdx).
 1. **Never invent contract addresses, chain IDs, or token addresses.** Use [`docs/get-started/networks-and-tokens.mdx`](../../docs/get-started/networks-and-tokens.mdx) (BASE Mainnet `8453`, Sepolia `84532`).
-2. **Never invent live values** (active model count, bid prices, latency). Link to `https://active.mor.org`.
+2. **Never invent live values** (active model count, bid prices, latency). Link `https://active.mor.org` and name the layer (ALL / ACTIVE / GATEWAY). Semantics: [`docs/ecosystem/active-status.mdx`](../../docs/ecosystem/active-status.mdx). Diagrams: https://tech.mor.org/active.html. Hosted API consumes GATEWAY, not `active_models.json`.
 3. **Never claim "Morpheus runs the inference."** Independent providers run inference; Morpheus is a marketplace coordinated by the Diamond contract on BASE.
 4. **Disambiguate the local `tinyllama` demo from real Morpheus models.** Cite [`docs/ai/local-vs-blockchain-models.mdx`](../../docs/ai/local-vs-blockchain-models.mdx).
 5. **Opening a session escrows MOR; it does not spend MOR.** Unused MOR returns on close. Cite [`docs/ai/session-states-open-close-recover.mdx`](../../docs/ai/session-states-open-close-recover.mdx).
-6. **There is no `recover` RPC.** Closing the session is the recovery path.
+6. **There is no `recover` RPC.** Closing the session is the recovery path. Day-lock claim is `POST /blockchain/stakes/withdraw`.
 7. **For TEE questions, separate Phase 1 (consumer → P-Node) from Phase 2 (P-Node → backend).** A v6+ consumer transparently benefits from a v7+ provider's Phase 2 with no client-side upgrade.
 8. **The proxy-router `:8082` admin/API port must not be exposed publicly.** Only `:3333` is public, and only on providers.
 9. **MorpheusUI mnemonic recovery only works for tier-1 (index 0) addresses.** For derived addresses, recommend importing the private key directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Read the **AI knowledge** pages before answering user questions:
 | Topic | Slug | Citation URL |
 |-------|------|--------------|
 | Architecture | `concepts/architecture` | https://nodedocs.mor.org/concepts/architecture |
+| Marketplace catalog (ALL / ACTIVE / GATEWAY) | `ecosystem/active-status` | https://nodedocs.mor.org/ecosystem/active-status — live files https://active.mor.org — explainer https://tech.mor.org/active.html |
 | Sessions, stake, close, recover | `concepts/sessions-stake-close-recover` | https://nodedocs.mor.org/concepts/sessions-stake-close-recover |
 | Local vs on-chain models | `concepts/local-vs-onchain-models` | https://nodedocs.mor.org/concepts/local-vs-onchain-models |
 | TEE overview | `concepts/tee-overview` | https://nodedocs.mor.org/concepts/tee-overview |
@@ -60,11 +61,11 @@ Read the **AI knowledge** pages before answering user questions:
 
 0. **Never confuse the proxy-router HTTP API with the hosted Morpheus Inference API.** The proxy-router API is documented locally at `http://localhost:8082/swagger/index.html` and in [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml). The hosted Morpheus Inference API is a **different product** at [apidocs.mor.org](https://apidocs.mor.org) (base URL `https://api.mor.org/api/v1`) — slug `inference-api/overview`.
 1. **Never invent contract addresses, chain IDs, or token addresses.** Use only what's in slug `get-started/networks-and-tokens` or release notes.
-2. **Never invent live values** (active model count, current bid prices, network status). Link out to `https://active.mor.org` instead.
+2. **Never invent live values** (active model count, current bid prices, network status). Link [active.mor.org](https://active.mor.org) JSON. Name the layer: **ALL** (`all_models.json` / `all_bids.json`), **ACTIVE** (`active_models.json` / `active_bids.json`), or **GATEWAY** (`gateway_models.json` / `gateway_bids.json`). The hosted API consumes GATEWAY, then still applies its allowlist — do not treat `active_models.json` as `api.mor.org`. Semantics: slug `ecosystem/active-status`; diagrams: [tech.mor.org/active.html](https://tech.mor.org/active.html).
 3. **Never claim Morpheus runs the inference itself.** Independent providers do; Morpheus is a marketplace coordinated by the Diamond contract on BASE.
 4. **Always disambiguate the local `tinyllama` demo from real Morpheus models.** They are not comparable.
 5. **Never describe "open a session" as "spending MOR."** The MOR is escrowed; unused stake returns on close.
-6. **Never tell users to call a `recover` RPC.** It does not exist. Closing the session is the recovery path.
+6. **Never tell users to call a `recover` RPC.** It does not exist. Closing the session is the recovery path. Day-locked used stipend is claimed with `POST /blockchain/stakes/withdraw` (or `withdrawUserStakes` on the Diamond) after `releaseAt` — that is not recover.
 7. **For TEE questions, distinguish Phase 1 (consumer → P-Node) from Phase 2 (P-Node → backend).** Phase 2 runs *inside* the v7+ provider's P-Node — a v6+ consumer benefits transparently with no client-side upgrade.
 8. **The proxy-router's `:8082` admin port should not be public** — only `:3333` (TCP) is public, and only on provider nodes.
 9. **MorpheusUI mnemonic-recover only works for tier-1 (index 0) addresses.** Don't suggest it for derived addresses; suggest private-key import instead.
@@ -84,7 +85,8 @@ Read the **AI knowledge** pages before answering user questions:
 | "How do I run TEE?" | `providers/full/secretvm-quickstart` | https://nodedocs.mor.org/providers/full/secretvm-quickstart |
 | "How do I run a provider on Railway?" | `providers/full/proxy-router-railway` | https://nodedocs.mor.org/providers/full/proxy-router-railway — https://youtu.be/-z-EPK11qmM |
 | "What contract address?" | `get-started/networks-and-tokens` | https://nodedocs.mor.org/get-started/networks-and-tokens |
-| "Where can I see live status?" | — | https://active.mor.org |
+| "Where can I see live status / which catalog file?" | `ecosystem/active-status` | https://nodedocs.mor.org/ecosystem/active-status — https://active.mor.org — explainer https://tech.mor.org/active.html |
+| "Where is my MOR on chain (wallet / session / on-hold)?" | `ai/where-is-my-mor` | https://nodedocs.mor.org/ai/where-is-my-mor — hosted checker https://tech.mor.org/session.html |
 
 ## When unsure / out-of-corpus questions
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The purpose of this software is to enable interaction with distributed, decentra
 
 The canonical documentation lives at **[nodedocs.mor.org](https://nodedocs.mor.org)**. Source files are in [`/docs`](docs/) and built with [Mintlify](https://mintlify.com). The site replaces the previous `00-overview.md` / `02-*.md` / `04-*.md` / `99-troubleshooting.md` set of files; old paths still resolve via redirects in [`docs/docs.json`](docs/docs.json).
 
-The site is structured around **role-based journeys** (consumer / prosumer / provider tiers), with anti-hallucination [AI knowledge](https://nodedocs.mor.org/ai/myths) pages and curated mirrors of the broader [ecosystem](https://nodedocs.mor.org/ecosystem/overview) ([mor.org](https://mor.org), [tech.mor.org](https://tech.mor.org), [active.mor.org](https://active.mor.org), [MyProvider](https://myprovider.mor.org), [Everclaw](https://everclaw.xyz), [NodeNeo](https://nodeneo.io), [app.mor.org](https://app.mor.org)).
+The site is structured around **role-based journeys** (consumer / prosumer / provider tiers), with anti-hallucination [AI knowledge](https://nodedocs.mor.org/ai/myths) pages and curated mirrors of the broader [ecosystem](https://nodedocs.mor.org/ecosystem/overview) ([mor.org](https://mor.org), [tech.mor.org](https://tech.mor.org) including the [ALL / ACTIVE / GATEWAY explainer](https://tech.mor.org/active.html), [active.mor.org](https://active.mor.org), [MyProvider](https://myprovider.mor.org), [Everclaw](https://everclaw.xyz), [NodeNeo](https://nodeneo.io), [app.mor.org](https://app.mor.org)).
 
 ## What's in this repo
 

--- a/docs/ai/llm-prompt-cheatsheet.mdx
+++ b/docs/ai/llm-prompt-cheatsheet.mdx
@@ -3,7 +3,7 @@ title: "LLM prompt cheatsheet"
 description: "Guidance for AI agents and coding assistants answering Morpheus questions: what to cite, what to never invent, and where to look first."
 audience: ["developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.9.0"
+last_verified: "v7.11.0"
 ---
 
 If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morpheus questions, follow these rules. They will keep you out of the most common hallucination traps.
@@ -17,7 +17,7 @@ If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morphe
 ## Rules of engagement
 
 1. **Never invent contract addresses, chain IDs, or token addresses.** Always cite [Networks and tokens](/get-started/networks-and-tokens). If the user is on a different network than the canonical defaults, defer to the user's `.env`.
-2. **Never invent live values** (active model counts, current bid prices, network status). Always link to [active.mor.org](https://active.mor.org) or the equivalent live source.
+2. **Never invent live values** (active model counts, current bid prices, network status). Always link [active.mor.org](https://active.mor.org) and name the layer: **ALL**, **ACTIVE**, or **GATEWAY**. Semantics: [Marketplace catalog](/ecosystem/active-status). Diagrams: [tech.mor.org/active.html](https://tech.mor.org/active.html). The hosted API reads GATEWAY (`gateway_models.json`), not `active_models.json`.
 3. **Never claim Morpheus runs the inference.** Providers do. The marketplace coordinates.
 4. **Always disambiguate the local `llama.cpp` demo from real Morpheus models.** See [Local vs blockchain models](/ai/local-vs-blockchain-models).
 5. **Always treat "where is my MOR?" as a diagnostic, not as evidence of bugs.** Walk through [Where is my MOR?](/ai/where-is-my-mor).
@@ -41,6 +41,7 @@ If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morphe
 | "What's the API auth?" | [API auth](/reference/api-auth) |
 | "What endpoints exist on the proxy-router?" | [API endpoints](/reference/api-endpoints) and [`proxy-router/docs/swagger.yaml`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/proxy-router/docs/swagger.yaml) |
 | "How do I use the hosted Morpheus Inference API (no node)?" | [Inference API overview](/inference-api/overview) and [apidocs.mor.org](https://apidocs.mor.org) |
+| "What models are live / which JSON should my app consume?" | [Marketplace catalog](/ecosystem/active-status) — live files on [active.mor.org](https://active.mor.org), explainer [tech.mor.org/active.html](https://tech.mor.org/active.html) |
 | "What's `models-config.json`?" | [models-config.json](/reference/models-config) |
 | "How do I price a bid?" | [Pricing a resale bid](/providers/resale/registering-bid) |
 
@@ -53,7 +54,7 @@ If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morphe
   - ✅ "Morpheus is a marketplace. Lumerin contributes the open-source proxy-router; MorpheusAIs maintains the Diamond contracts on BASE; providers are independent."
 
 - ❌ "Open a session and your MOR is gone."
-  - ✅ "Opening a session escrows MOR; unused MOR returns on close; used stipend day-locks until the next UTC day (`withdrawUserStakes`)."
+  - ✅ "Opening a session escrows MOR; unused MOR returns on close; used stipend day-locks until the next UTC day. Claim with `POST /blockchain/stakes/withdraw` (or `withdrawUserStakes` on the Diamond) after `releaseAt`. There is no `recover` RPC."
 
 - ❌ "Natural expiration returns the full stake with no hold / you can recycle MOR all day."
   - ✅ "Used stipend day-locks on early and same-day natural close. Size consumer float for gross daily stake."
@@ -61,8 +62,8 @@ If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morphe
 - ❌ "Use this contract address: 0x...." (invented)
   - ✅ "Per Networks and tokens, the BASE Mainnet Diamond contract is `0x6aBE1d282f72B474E54527D93b979A4f64d3030a`. Confirm against the latest release."
 
-- ❌ "Phase 2 needs a v7+ consumer."
-  - ✅ "Phase 2 runs inside the v7+ provider's P-Node. Any v6+ consumer benefits transparently."
+- ❌ "`active_models.json` is the hosted API catalog / what `api.mor.org` lists."
+  - ✅ "active.mor.org publishes **ALL / ACTIVE / GATEWAY** from the same sweep. The hosted API consumes **GATEWAY** (`gateway_models.json`), then still applies its allowlist. Name the layer. Semantics: [Marketplace catalog](/ecosystem/active-status)."
 
 ## Repository pointers
 

--- a/docs/ai/myths.mdx
+++ b/docs/ai/myths.mdx
@@ -3,7 +3,7 @@ title: "Common myths and corrections"
 description: "Concise corrections of the most frequent wrong assumptions about Morpheus, written for both humans and LLMs."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.9.0"
+last_verified: "v7.11.0"
 ---
 
 If you are an AI assistant answering Morpheus questions, **read this page before responding**. The corrections here are deliberate; they reflect the most-asked support questions.
@@ -112,5 +112,5 @@ If you are an AI agent or coding assistant unsure how to answer a Morpheus quest
 
 1. Check this page.
 2. Then check the relevant concept page in `/concepts/`.
-3. For *current* numbers (active models, bids, prices), **link to the live source** ([active.mor.org](https://active.mor.org), [tech.mor.org](https://tech.mor.org)) — never invent values.
+3. For *current* numbers (active models, bids, prices), **link the live JSON** on [active.mor.org](https://active.mor.org) and **name the layer** (ALL / ACTIVE / GATEWAY) — [Marketplace catalog](/ecosystem/active-status). Diagrams: [tech.mor.org/active.html](https://tech.mor.org/active.html). Never invent values.
 4. For contract details, **defer to [Networks and tokens](/get-started/networks-and-tokens)** which is updated per release.

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -3,7 +3,7 @@ title: "Architecture"
 description: "How the proxy-router, MorpheusUI, models, and BASE blockchain compose into a working consumer/provider system."
 audience: ["consumer", "prosumer", "provider-resale", "provider-full", "developer"]
 product: ["proxy-router", "ui-desktop", "cli"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 ---
 
 This page documents the **structural** picture: which process runs where, which port talks to which port, and what is on chain vs off chain. For dynamics over time (sessions, MOR flows), see [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
@@ -74,6 +74,8 @@ sequenceDiagram
 | MOR ERC-20 transfers | Wallet management UI |
 
 Once a session is established, **prompts and responses flow peer-to-peer between consumer and provider** — they never traverse a Morpheus-operated server. The blockchain only sees session open / close / settle.
+
+Applications that need a **shared catalog** (hosted API, NodeNeo, calculators) should consume [active.mor.org](/ecosystem/active-status) instead of rediscovering bids per request. That site photographs the same walk a C-Node does before `SESSION_HEALTH_POLICY` and escrow; it does not open sessions. Pick ALL, ACTIVE, or GATEWAY. Illustrated: [tech.mor.org/active.html](https://tech.mor.org/active.html).
 
 ## Reputation and provider selection
 

--- a/docs/consumers/buy-bid.mdx
+++ b/docs/consumers/buy-bid.mdx
@@ -3,7 +3,7 @@ title: "Open a session (buy a bid)"
 description: "How to open a Morpheus session via MorpheusUI or the API: pick a model, select a bid, stake MOR, and what happens next."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.9.0"
+last_verified: "v7.11.0"
 source: "docs/05-bid-purchase.md"
 ---
 
@@ -30,7 +30,7 @@ Opening a session = "buying a bid." You stake MOR for a fixed duration; the prox
     - **Natural expiration** — your consumer node submits `closeSession` ~1 minute after `endsAt` (if online).
     - **Early close** — click the time icon next to the model line; click **X** next to the session.
 
-    In both cases: **unused** stake returns in the close txn; the **used stipend** day-locks in `userStakesOnHold` until the next UTC day. After `releaseAt`, call `withdrawUserStakes` to claim the held slice.
+    In both cases: **unused** stake returns in the close txn; the **used stipend** day-locks in `userStakesOnHold` until the next UTC day. After `releaseAt`, claim with `POST /blockchain/stakes/withdraw` (or `withdrawUserStakes` on the Diamond). There is no `recover` RPC.
   </Step>
 </Steps>
 
@@ -71,6 +71,6 @@ There is no single right answer; consider:
 - **`pricePerSecond`** — lower is cheaper but providers compete on quality and uptime.
 - **Provider reputation / stake** — higher provider stake means more skin in the game.
 - **TEE vs non-TEE** — `tee`-tagged models give you cryptographic guarantees about the running software (see [TEE overview](/concepts/tee-overview)).
-- **Throughput / capacity** — see live data at [active.mor.org](https://active.mor.org).
+- **Throughput / capacity** — live files at [active.mor.org](https://active.mor.org). Name the layer ([Marketplace catalog](/ecosystem/active-status)); C-Node apps usually want **ACTIVE**. Explainer: [tech.mor.org/active.html](https://tech.mor.org/active.html).
 
 For a `rating-config.json` that prefers certain providers automatically, see [rating-config](/reference/rating-config).

--- a/docs/consumers/troubleshooting.mdx
+++ b/docs/consumers/troubleshooting.mdx
@@ -3,7 +3,7 @@ title: "Consumer troubleshooting"
 description: "The most common consumer-side problems and their fixes."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.9.0"
+last_verified: "v7.11.0"
 ---
 
 This page focuses on consumer-side symptoms. For provider-side or deeper proxy-router operational issues, see the full [Reference: troubleshooting](/reference/troubleshooting).
@@ -22,7 +22,7 @@ You probably recovered a **derived** address from your mnemonic. MorpheusUI only
 ## "Provider not responding" or stuck mid-prompt
 
 - Confirm the proxy-router is still running (`http://localhost:8082/healthcheck`, or check the Proxy Router entry on MorpheusUI's startup screen).
-- The provider may be down. Close the session; unused stake returns immediately, and the used stipend in `userStakesOnHold` becomes claimable via `withdrawUserStakes` after ~1 UTC day:
+- The provider may be down. Close the session; unused stake returns immediately, and the used stipend in `userStakesOnHold` becomes claimable after ~1 UTC day via `POST /blockchain/stakes/withdraw` (or `withdrawUserStakes` on the Diamond):
   ```bash
   curl -X POST 'http://localhost:8082/blockchain/sessions/<sessionId>/close' \
     -H 'Authorization: Basic <base64(user:pass)>' -d '{}'

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,6 +44,7 @@
             "pages": [
               "concepts/what-is-morpheus",
               "concepts/architecture",
+              "ecosystem/active-status",
               "concepts/sessions-stake-close-recover",
               "concepts/local-vs-onchain-models",
               "concepts/tee-overview",
@@ -229,8 +230,16 @@
             "href": "https://active.mor.org/status"
           },
           {
+            "label": "Catalog explainer",
+            "href": "https://tech.mor.org/active.html"
+          },
+          {
             "label": "Active models",
             "href": "https://active.mor.org/active_models"
+          },
+          {
+            "label": "Gateway models",
+            "href": "https://active.mor.org/gateway_models.json"
           },
           {
             "label": "Active bids",

--- a/docs/ecosystem/active-status.mdx
+++ b/docs/ecosystem/active-status.mdx
@@ -1,58 +1,110 @@
 ---
-title: "active.mor.org (live status)"
-description: "Mirror summary of active.mor.org — live status, active models, and active bids on the Morpheus marketplace."
-audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
-product: ["proxy-router"]
-last_verified: "v7.5.0"
+title: "Marketplace catalog (active.mor.org)"
+description: "active.mor.org is the shared ~5-minute photograph of the Morpheus marketplace. Applications pick ALL, ACTIVE, or GATEWAY from the same sweep instead of rediscovering bids per request."
+audience: ["developer", "prosumer", "provider-full", "provider-resale", "consumer"]
+product: ["proxy-router", "inference-api"]
+last_verified: "v7.11.0"
 source_url: "https://active.mor.org"
 ---
 
 <Note>
-**Mirrored summary.** Live numbers (counts, prices, latencies) live at [active.mor.org](https://active.mor.org). This page describes the **semantics** of those numbers and how to interpret them. Providers: start here **before** minting a new model — see [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
+**Live files** are on [active.mor.org](https://active.mor.org). **Semantics** (what ALL / ACTIVE / GATEWAY mean, which file to consume) live on this page. The illustrated explainer is [tech.mor.org/active.html](https://tech.mor.org/active.html). Never invent model counts, bid prices, or latencies — link the live JSON.
 </Note>
 
-## What's there
+[active.mor.org](https://active.mor.org) is the common catalog surface for **any application builder** on Morpheus: the hosted Inference API, NodeNeo, calculators, C-Node clients, and humans. A consumer node, before it opens a session, still has to ping providers, read `models[]`, apply `SESSION_HEALTH_POLICY`, then **escrow** MOR. The status site does that walk on a timer (~five minutes) and publishes **three views of the same sweep** so apps do not repeat it on every request.
 
-| Endpoint | What it shows | Useful for |
-|----------|---------------|-----------|
-| [active.mor.org/status](https://active.mor.org/status) | Human status UI (uptime, min prices, model detail) | Spotting outages; picking a model to join |
-| [active_models.json](https://active.mor.org/active_models.json) | Routable models (healthy/degraded bids) | Choosing what to consume; **finding an existing `Id` to bid on** |
-| [active_bids.json](https://active.mor.org/active_bids.json) | Currently posted bids across all models | Pricing decisions; competitive analysis |
-| [all_models.json](https://active.mor.org/all_models.json) | All non-deleted on-chain models | Lookup when a model has no live healthy provider yet |
-| [status/api.json](https://active.mor.org/status/api.json) | Machine-readable status summary | Monitoring / agents |
+It does **not** open sessions, hold MOR, or run inference. Independent providers still do that. Closing a session is still the recovery path — there is no `recover` RPC.
+
+## Pick a layer
+
+Each layer is a subset of the one above, from the **same** photograph.
+
+| Layer | Keep | Drop | Typical reader |
+|-------|------|------|----------------|
+| **RAW** | Everything ever registered on-chain | — | Chain explorers / full history. Not a working catalog. |
+| **ALL** | Non-deleted models and open bids (`DeletedAt = 0`), with an honest health stamp on every bid | Expired / deleted | Ops, status debugging, any app that needs **failures** too |
+| **ACTIVE** | Polled working set: `skipped`, `degraded`, `healthy` | `unreachable`, `unreported`, `no_model_configured`, `no_bid`, `tee_unverified`, `unhealthy` | NodeNeo, C-Nodes, other apps whose policy can still refuse `skipped` or `degraded` |
+| **GATEWAY** | Tested/openable: `healthy` + `degraded`, plus name aliases | `skipped` (and everything ACTIVE already dropped) | Hosted Inference API (`api.mor.org`) |
+
+**Do not mix the files.** `active_models.json` is **ACTIVE**, not GATEWAY. The hosted API consumes **GATEWAY**, then still applies its own allowlist / fuse / refuse-at-open. A model on GATEWAY is not a promise it is callable through `api.mor.org`.
+
+Visual funnel (RAW → ALL → ACTIVE → GATEWAY) and the native health pipeline: [tech.mor.org/active.html](https://tech.mor.org/active.html).
+
+## Files
+
+JSON snapshots refresh on a short cron (on the order of minutes). Field names are PascalCase (`Id`, `Name`, `ModelName`, `PricePerSecond`, `Provider`, …). `pricePerSecond` is MOR wei per second.
+
+| URL | Layer | Use |
+|-----|-------|-----|
+| [all_models.json](https://active.mor.org/all_models.json) / [all_bids.json](https://active.mor.org/all_bids.json) | ALL | Full current photograph, including failed stamps. Start here when you need to know **why** a bid is missing from ACTIVE. |
+| [active_models.json](https://active.mor.org/active_models.json) / [active_bids.json](https://active.mor.org/active_bids.json) | ACTIVE | Polled working set (includes `skipped`). Default for NodeNeo / C-Node-style apps. |
+| [gateway_models.json](https://active.mor.org/gateway_models.json) / [gateway_bids.json](https://active.mor.org/gateway_bids.json) | GATEWAY | Healthy + degraded + aliases. Default input for the hosted API. |
+| [status](https://active.mor.org/status) | Human UI | Uptime, min prices, model detail. Status HTML currently reads the **ACTIVE** slice (grey `skipped`). |
+| [status/api.json](https://active.mor.org/status/api.json) | Machine summary | Monitoring / agents |
 
 HTML list views also exist at `/active_models` and `/active_bids` on the same host.
 
-## Provider tip: join, don't duplicate
-
-The marketplace does not stop two people from registering the same display name as separate models. That creates clutter. If you intend to serve a model that already appears in `active_models.json`, **register as a provider and bid on that model's `Id`** (via [MyProvider](/providers/full/myprovider-gui) or the API). Mint a new model only for genuinely new weights or a required new `tee` listing.
-
 ```bash
+# ACTIVE working set (includes skipped)
 curl -sS https://active.mor.org/active_models.json \
-  | jq '.models[] | select(.Name | test("glm-5"; "i")) | {Name, Id, Tags, health}'
+  | jq '.models[] | select(.Name | test("llama-3.3"; "i")) | {Name, Id, Tags, health}'
+
+# GATEWAY (hosted-API input — healthy + degraded only)
+curl -sS https://active.mor.org/gateway_models.json \
+  | jq '.models[] | {Name, Id, aliases, health}'
+
+# Competing bids for a name (ACTIVE slice)
+curl -sS https://active.mor.org/active_bids.json \
+  | jq '[.bids[] | select(.ModelName | test("llama-3.3"; "i"))] | sort_by(.PricePerSecond | tonumber) | .[:5]'
 ```
 
-## How to read it
+## Stamps (ALL)
 
-- **A model "active" here means `(at least one bid posted) AND (provider healthcheck passes)`.** A model on chain that has no healthy provider won't show up in `active_models.json` even if its Diamond record exists — check `all_models.json` in that case.
-- Snapshot fields use PascalCase (`Id`, `Name`, `ModelName`, `PricePerSecond`, `Provider`, …).
-- **`pricePerSecond`** values are MOR wei per second. Many UIs also show `priceMorPerHour`.
-- Snapshots refresh on a short cron (on the order of minutes); a brand-new bid may take a few minutes to appear.
+Step 1 is on-chain: the bid/model is not deleted. Steps 2–10 are mutually exclusive health stamps on that sweep. The lambda invents only `unreachable` and `unreported`; stamps 4–10 come from the provider's `models[]` self-report (see [Model health](/providers/full/model-health)).
+
+| # | Stamp | Where it lives |
+|---|-------|----------------|
+| 2 | `unreachable` | ALL only |
+| 3 | `unreported` | ALL only |
+| 4 | `no_model_configured` | ALL only |
+| 5 | `no_bid` | ALL only |
+| 6 | `tee_unverified` | ALL only |
+| 7 | `unhealthy` | ALL only |
+| 8 | `skipped` | ALL and **ACTIVE** (GATEWAY drops it) |
+| 9 | `degraded` | ALL, ACTIVE, GATEWAY |
+| 10 | `healthy` | ALL, ACTIVE, GATEWAY |
+
+`skipped` is still **routable** under a C-Node's default `SESSION_HEALTH_POLICY=permissive`. GATEWAY drops it because the hosted API only wants tested chat/embedding-style completions. Untagged / unknown-type models are LLM-probed since v7.11; a failed **guess** reports `skipped` (with `errorKind` still set), not `unhealthy`. Media-tagged models (image / video / audio / music) stay `skipped` without a probe.
+
+## Provider tip: join, don't duplicate
+
+The marketplace does not stop two people from registering the same display name as separate models. If you intend to serve a model that already appears in `active_models.json` (or `all_models.json` if it has no live bid yet), **register as a provider and bid on that model's `Id`**. Mint a new model only for genuinely new weights or a required new `tee` listing. See [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
+
+## C-Node vs the photograph
+
+| | Your C-Node (per session) | active.mor.org (~5 min) |
+|--|---------------------------|-------------------------|
+| Job | Ping, policy, **escrow MOR**, route prompts | Shared catalog so apps do not rediscover bids |
+| Policy | `SESSION_HEALTH_POLICY` can still refuse `skipped` / `degraded` / unknown reports | Publishes all three layers; the **app picks** |
+| MOR | Opening a session escrows; unused returns on close | Never holds MOR |
+
+For wallet buckets after close, use [tech.mor.org/session.html](https://tech.mor.org/session.html) and [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
 
 ## When to cite this page
 
-For an LLM answering "what models are available?" or "what's the going rate?" — **link out** to the appropriate sub-path of `active.mor.org`. Never invent counts or prices.
+For an LLM answering "what models are available?", "why isn't this on the API?", or "what's the going rate?" — **link the matching JSON**, name the layer (ALL / ACTIVE / GATEWAY), and never invent counts or prices. For "why does this photograph exist?" send humans to [tech.mor.org/active.html](https://tech.mor.org/active.html).
 
-## Related canonical pages on this site
+## Related
 
+- [tech.mor.org — ALL, ACTIVE, GATEWAY](https://tech.mor.org/active.html) (illustrated explainer)
 - [Register on chain](/providers/full/register-onchain)
-- [MyProvider GUI](/providers/full/myprovider-gui)
-- [Architecture](/concepts/architecture)
-- [Pricing a resale bid](/providers/resale/registering-bid)
-- [Buy a bid](/consumers/buy-bid)
+- [Model health self-report](/providers/full/model-health)
+- [Hosted Inference API](/inference-api/overview)
+- [NodeNeo](/ecosystem/nodeneo)
+- [tech.mor.org (site index)](/ecosystem/tech-mor-org)
 - [Glossary](/reference/glossary)
 
 ## Source
 
 - [https://active.mor.org](https://active.mor.org)
-- [https://active.mor.org/status](https://active.mor.org/status)
+- [https://tech.mor.org/active.html](https://tech.mor.org/active.html)

--- a/docs/ecosystem/attribution.mdx
+++ b/docs/ecosystem/attribution.mdx
@@ -3,7 +3,7 @@ title: "Ecosystem attribution"
 description: "Sources, licenses, and refresh policy for the mirrored ecosystem pages."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 ---
 
 The pages under [Ecosystem](/ecosystem/overview) are **curated summaries** of public material from the broader Morpheus ecosystem. We mirror **conceptual content** (what something is for, how it relates to the rest of Morpheus); we **do not** snapshot live data (counts, prices, status).
@@ -31,7 +31,7 @@ The pages under [Ecosystem](/ecosystem/overview) are **curated summaries** of pu
 | Page | Source URL |
 |------|-----------|
 | [mor.org](/ecosystem/mor-org) | https://mor.org |
-| [active.mor.org](/ecosystem/active-status) | https://active.mor.org |
+| [active.mor.org](/ecosystem/active-status) | https://active.mor.org — explainer https://tech.mor.org/active.html |
 | [tech.mor.org](/ecosystem/tech-mor-org) | https://tech.mor.org |
 | [MyProvider](/ecosystem/myprovider) | https://myprovider.mor.org |
 | [Everclaw](/ecosystem/everclaw) | https://everclaw.xyz |

--- a/docs/ecosystem/nodeneo.mdx
+++ b/docs/ecosystem/nodeneo.mdx
@@ -17,7 +17,7 @@ NodeNeo is a cross-platform consumer-side experience for Morpheus — a compleme
 
 ## How it relates to this repo
 
-- Under the hood, NodeNeo speaks to a Morpheus C-Node — the same proxy-router code documented on this site.
+- Under the hood, NodeNeo speaks to a Morpheus C-Node — the same proxy-router code documented on this site. For a **shared catalog** without rediscovering bids, consume the **ACTIVE** slice on [active.mor.org](/ecosystem/active-status) (policy can still refuse `skipped` / `degraded`). ALL if you need failures too. GATEWAY is the hosted-API input, not NodeNeo's default.
 - A user can be a NodeNeo user while also running MorpheusUI on a desktop; they are separate clients sharing a common wallet (if configured).
 
 ## When to cite NodeNeo

--- a/docs/ecosystem/overview.mdx
+++ b/docs/ecosystem/overview.mdx
@@ -3,7 +3,7 @@ title: "Ecosystem overview"
 description: "Index of mirrored summaries of the broader Morpheus ecosystem — what each surface is for, and where to read more."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 ---
 
 These pages are **curated mirrors** of the broader Morpheus ecosystem so AI agents reading this repo can answer ecosystem questions in one place. Each page is a **summary**, not a snapshot of live data — for current numbers we link out.
@@ -15,10 +15,10 @@ These pages are **curated mirrors** of the broader Morpheus ecosystem so AI agen
     The marketing / orientation hub for Morpheus.
   </Card>
   <Card title="active.mor.org" icon="signal" href="/ecosystem/active-status">
-    Live status, active models, active bids.
+    Shared catalog photograph — pick ALL, ACTIVE, or GATEWAY.
   </Card>
   <Card title="tech.mor.org" icon="calculator" href="/ecosystem/tech-mor-org">
-    Calculators, sessions, TEE, throughput explainers.
+    Explainers: funnel, sessions, TEE, calculator, throughput.
   </Card>
   <Card title="MyProvider" icon="server" href="/ecosystem/myprovider">
     Hosted operator GUI for provider node management.

--- a/docs/ecosystem/tech-mor-org.mdx
+++ b/docs/ecosystem/tech-mor-org.mdx
@@ -1,42 +1,51 @@
 ---
-title: "tech.mor.org (calculators, sessions, TEE, throughput)"
-description: "Mirror summary of tech.mor.org — Morpheus's technical explainer site with calculators and protocol-level documentation."
+title: "tech.mor.org (explainers)"
+description: "tech.mor.org is Morpheus's technical explainer site: throughput, spectrum, calculator, TEE, session lifecycle, and the ALL / ACTIVE / GATEWAY catalog funnel."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 source_url: "https://tech.mor.org"
 ---
 
 <Note>
-**Mirrored summary.** [tech.mor.org](https://tech.mor.org) is the canonical place for Morpheus protocol-level explainers and live calculators. This page summarizes what's there and how it relates to this site.
+**Mirrored summary.** [tech.mor.org](https://tech.mor.org) is the illustrated protocol site. This page lists what is there. Live catalog **files** stay on [active.mor.org](/ecosystem/active-status); live counts stay on those files — never invent them here.
 </Note>
 
-## Sections
+`tech.mor.org` is the place to **understand** the marketplace (funnels, session buckets, TEE phases, pricing math). This nodedocs site is the place to **operate** the proxy-router. They share the same facts; they do not duplicate the diagrams.
 
-| Sub-area | What it covers | This site's parallel |
-|----------|----------------|----------------------|
-| **Calculators** | Provider revenue, token-throughput, hardware sizing | (Use the live calculators on `tech.mor.org`) |
-| **Sessions** | Open / close / settle mechanics | [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover) |
-| **TEE** | The two-hop trust chain, RTMR3, attestation | [TEE overview](/concepts/tee-overview), [TEE reference](/providers/full/tee-reference) |
-| **Throughput** | TPS / TTFT / latency expectations | [Architecture](/concepts/architecture) |
+## Pages
+
+| Page | What it covers | This site's parallel |
+|------|----------------|----------------------|
+| [Home / throughput](https://tech.mor.org/) | On-chain SessionClosed aggregates (sessions, TTFT, stuck-session health). Also `/throughput.html`. | [Architecture](/concepts/architecture) |
+| [Field guide hub](https://tech.mor.org/index.html) | Index of the interactive tools | This page |
+| [AI Trust Spectrum](https://tech.mor.org/spectrum.html) | Seven ways to use AI, scored on trust dimensions | [What is Morpheus?](/concepts/what-is-morpheus) |
+| [Pricing & staking calculator](https://tech.mor.org/calc.html) | Gateway vs direct-path cost; staking yields | [Tokens and fees](/concepts/tokens-and-fees) |
+| [TEE roadmap](https://tech.mor.org/tee.html) | Pre-TEE → Phase 1 → Phase 2, attestation flow | [TEE overview](/concepts/tee-overview) |
+| [MOR session lifecycle](https://tech.mor.org/session.html) | Open → close → on-hold → withdraw; read-only wallet checker for the three on-chain buckets | [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover) |
+| [ALL, ACTIVE, GATEWAY](https://tech.mor.org/active.html) | **Why active.mor.org exists** — shared ~5-minute photograph so apps pick a catalog layer instead of rediscovering bids | [Marketplace catalog](/ecosystem/active-status) |
+| [AI assistant guide](https://tech.mor.org/AI_ASSISTANT_GUIDE.md) | Agent-oriented pricing / session / curl notes | [LLM prompt cheatsheet](/ai/llm-prompt-cheatsheet) |
+
+The session checker samples recent sessions for speed; a full on-chain reconcile can undercount older unclosed sessions. If the page and this repo disagree on day-lock rules, **this repo / the contract win**.
 
 ## How they relate
 
-- Conceptual / architectural narratives live in **both places**, but this site is biased toward *operating* the proxy-router; `tech.mor.org` is biased toward *understanding the protocol*.
-- For *live* numbers (TPS / capacity / current network state), use [active.mor.org](/ecosystem/active-status).
-- Calculators are interactive on `tech.mor.org`; we don't snapshot them.
+- Conceptual narratives live in **both** places. Stay here for "how do I run the node?"; use `tech.mor.org` for "show me the funnel / calculator / wallet buckets."
+- For *live* catalog files and stamps, use [active.mor.org](/ecosystem/active-status). For *why those three layers exist*, use [active.html](https://tech.mor.org/active.html).
+- Calculators are interactive on `tech.mor.org`; we do not snapshot their outputs.
 
 ## When to cite this page
 
-For protocol-level "why does it work this way?" questions, link to `tech.mor.org`. For "how do I run the proxy-router?" questions, stay on this site.
+Protocol-level "why does it work this way?" — link the matching `tech.mor.org` URL. Operational "how do I run the proxy-router?" — stay on this site.
 
-## Related canonical pages on this site
+## Related
 
-- [Concepts → Sessions](/concepts/sessions-stake-close-recover)
-- [Concepts → TEE overview](/concepts/tee-overview)
-- [Concepts → Tokens and fees](/concepts/tokens-and-fees)
-- [Providers → TEE reference](/providers/full/tee-reference)
+- [Marketplace catalog (active.mor.org)](/ecosystem/active-status)
+- [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover)
+- [TEE overview](/concepts/tee-overview)
+- [Tokens and fees](/concepts/tokens-and-fees)
 
 ## Source
 
 - [https://tech.mor.org](https://tech.mor.org)
+- [https://tech.mor.org/llms.txt](https://tech.mor.org/llms.txt)

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -3,7 +3,7 @@ title: "Introduction"
 description: "What the Morpheus Lumerin Node is, how the moving parts fit together, and which path to follow next."
 audience: ["consumer", "prosumer", "provider-resale", "provider-full", "developer"]
 product: ["proxy-router", "ui-desktop", "cli"]
-last_verified: "v7.6.0"
+last_verified: "v7.11.0"
 ---
 <Note>
   **In a hurry? Pick the fastest path.**
@@ -15,7 +15,7 @@ last_verified: "v7.6.0"
     [Consumer quickstart](/consumers/quickstart).
   - **Try it free — no wallet, no tokens:** after install, the app also downloads a local `llama.cpp`
     demo model so you can chat without staking MOR. Look for **Local Model** in Chat.
-  - **Building on the marketplace?** jump to the [Hosted Inference API](/inference-api/overview).
+  - **Building on the marketplace?** Jump to the [hosted Inference API](/inference-api/overview), or consume the shared catalog on [active.mor.org](/ecosystem/active-status) (pick ALL / ACTIVE / GATEWAY).
 
   New to Morpheus? Read on for how the pieces fit together.
 </Note>

--- a/docs/get-started/quickstart-provider.mdx
+++ b/docs/get-started/quickstart-provider.mdx
@@ -36,7 +36,7 @@ This page is the high-level checklist. For the full setup, branch into one of:
     OpenAI-compatible endpoint reachable from your proxy-router host (e.g. `http://my-model:8080/v1/chat/completions`).
   </Step>
   <Step title="Look up what already exists">
-    Before minting a new marketplace model, check [active.mor.org/status](https://active.mor.org/status) (or `active_models.json` / `active_bids.json`) for the model name you intend to serve and competing prices. Prefer **bidding on an existing `modelId`**. See [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
+    Before minting a new marketplace model, check [active.mor.org/status](https://active.mor.org/status) (or the JSON layers on [active.mor.org](/ecosystem/active-status) — usually `active_models.json` / `active_bids.json`) for the model name you intend to serve and competing prices. Prefer **bidding on an existing `modelId`**. See [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
   </Step>
   <Step title="Have a funded wallet">
     BASE wallet with enough MOR for provider stake + bid fee (and model stake only if you must mint a new model), plus a little ETH for gas. See [Networks and tokens](/get-started/networks-and-tokens).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,7 +3,7 @@ title: "Morpheus Lumerin Node Docs"
 description: "The canonical knowledge base for Morpheus DeAI: consumers, providers, the proxy-router API, TEE attestation, and the broader Morpheus ecosystem. Curated for humans and AI agents."
 sidebarTitle: "Welcome"
 audience: ["consumer", "prosumer", "provider-resale", "provider-full", "developer"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 ---
 
 The Morpheus Lumerin Node is the open-source software that lets a desktop chat experience talk to distributed, decentralized LLMs on the Morpheus network. This documentation is the **canonical, human-and-agent-friendly source of truth** for installing, running, and operating that software.
@@ -36,7 +36,7 @@ The Morpheus Lumerin Node is the open-source software that lets a desktop chat e
 
 <CardGroup cols={3}>
   <Card title="Concepts" icon="book" href="/concepts/architecture">
-    Architecture, sessions, TEE, tokens — what every user should understand once.
+    Architecture, catalog layers, sessions, TEE, tokens.
   </Card>
   <Card title="API endpoints" icon="code" href="/reference/api-endpoints">
     Curated subset of the proxy-router HTTP API; full schema in [`proxy-router/docs/swagger.yaml`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/proxy-router/docs/swagger.yaml).
@@ -45,7 +45,7 @@ The Morpheus Lumerin Node is the open-source software that lets a desktop chat e
     Anti-hallucination pages: where is my MOR, session states, locked-in-contract.
   </Card>
   <Card title="Ecosystem" icon="globe" href="/ecosystem/overview">
-    Mirrors of mor.org, NodeNeo, Everclaw, MyProvider, with attribution.
+    active.mor.org catalog, tech.mor.org explainers, NodeNeo, Everclaw, MyProvider.
   </Card>
   <Card title="Reference" icon="gear" href="/reference/api-overview">
     Env vars, configs, troubleshooting, glossary.
@@ -57,10 +57,10 @@ The Morpheus Lumerin Node is the open-source software that lets a desktop chat e
 
 ## Live network resources
 
-These pages link out to **live data** that changes too often to mirror:
+These pages link out to **live data** that changes too often to mirror. Semantics for the catalog (ALL / ACTIVE / GATEWAY) are on this site so builders pick the right file:
 
-- **Status, active models, active bids** — [active.mor.org](https://active.mor.org)
-- **Calculators, sessions, TEE, throughput** — [tech.mor.org](https://tech.mor.org)
+- **Marketplace catalog** — [active.mor.org](https://active.mor.org) files; [what ALL / ACTIVE / GATEWAY mean](/ecosystem/active-status); illustrated explainer [tech.mor.org/active.html](https://tech.mor.org/active.html)
+- **Sessions, calculator, TEE, throughput** — [tech.mor.org](https://tech.mor.org)
 - **Provider portal** — [myprovider.mor.org](https://myprovider.mor.org)
 - **Hosted Inference API** (separate product, OpenAI-compatible) — [apidocs.mor.org](https://apidocs.mor.org)
 

--- a/docs/inference-api/overview.mdx
+++ b/docs/inference-api/overview.mdx
@@ -3,7 +3,7 @@ title: "Morpheus Inference API (hosted)"
 description: "Use Morpheus inference via a hosted OpenAI-compatible HTTPS gateway — no node, no wallet, just an API key."
 audience: ["api-user", "developer"]
 product: ["inference-api"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 source_url: "https://apidocs.mor.org"
 ---
 
@@ -68,7 +68,7 @@ Same pattern for the Vercel AI SDK, LangChain, Eliza, n8n, Cursor, OpenCode, Ope
 
 - **Not the proxy-router HTTP API.** That's a different surface — a local API exposed by the [proxy-router](/concepts/architecture) on `:8082` when you self-host. If you're running a node, you talk to it directly; you do not use `api.mor.org` for that.
 - **Not the only way to use Morpheus.** It's the easiest, but you give up self-custody of the wallet and direct on-chain control of sessions in exchange. Casual chat users with the same trade-off can use [app.mor.org](/ecosystem/app-mor-org) directly (no API integration needed).
-- **Not the whole marketplace.** The list of models exposed through `apidocs.mor.org` / `app.mor.org` is the **bootstrap set** the gateway curated when the system launched — not every model on the marketplace. Independent providers can register additional models and bids on chain that won't appear in the gateway's catalog. To see the live full marketplace, query [active.mor.org/active_models.json](https://active.mor.org/active_models.json) and [active.mor.org/active_bids.json](https://active.mor.org/active_bids.json), or run your own proxy-router and use [`GET /blockchain/models`](/reference/api-endpoints#get-models).
+- **Not the whole marketplace.** The list of models exposed through `apidocs.mor.org` / `app.mor.org` is the hosted gateway's **allowlisted** set, not every bid on chain. The gateway's catalog **input** is the **GATEWAY** slice on [active.mor.org](https://active.mor.org) (`gateway_models.json` — healthy + degraded + aliases). Independent providers can register additional models that appear on **ALL** or **ACTIVE** and still never show up on the hosted API. To see the live marketplace, pick a layer: [Marketplace catalog](/ecosystem/active-status). Illustrated explainer: [tech.mor.org/active.html](https://tech.mor.org/active.html). A self-hosted C-Node uses [`GET /blockchain/models`](/reference/api-endpoints#get-models) plus `SESSION_HEALTH_POLICY`, not the GATEWAY file.
 
 ## Pricing
 
@@ -91,5 +91,6 @@ The Inference API is built on the same Morpheus marketplace this repo's proxy-ro
 
 - [What is Morpheus?](/concepts/what-is-morpheus)
 - [Architecture](/concepts/architecture)
+- [Marketplace catalog (active.mor.org)](/ecosystem/active-status)
 - [Hosted consumer surface — app.mor.org / Morpheus Chat App](/ecosystem/app-mor-org)
 - [Self-hosted consumer alternative — C-Node setup](/prosumers/c-node-setup)

--- a/docs/providers/full/model-health.mdx
+++ b/docs/providers/full/model-health.mdx
@@ -3,13 +3,13 @@ title: "Model health self-report"
 description: "How the provider's built-in model health checker works: what it probes, what it costs your backend, how to tune the schedule, and how to read the report to diagnose failing models."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.4.0"
+last_verified: "v7.11.0"
 ---
 
 Since v7.4.0 every provider proxy-router continuously verifies that the models it sells actually work, and publishes the result as a `models` array on its `/healthcheck` endpoint. This page is the operational reference for that capability: what runs, what it costs, how to tune it, and how to read the report when something is unhealthy. For the one-time post-setup walkthrough, see [Verify your provider setup](/providers/full/verify-setup).
 
 <Note>
-The `httpStatus` and `modelName` report fields, the `rate_limited` error kind, probe pacing (`MODEL_HEALTH_CHECK_PROBE_DELAY`), and the manual `POST /healthcheck/models/refresh` trigger were added in the release **after** v7.4.0. On v7.4.0 nodes you get the report without those features. The `degraded` status (rate-limited backends) and the consumer-side `SESSION_HEALTH_POLICY` were added later still; on earlier nodes a rate-limited backend reports `unhealthy` with `errorKind: rate_limited`.
+The `httpStatus` and `modelName` report fields, the `rate_limited` error kind, probe pacing (`MODEL_HEALTH_CHECK_PROBE_DELAY`), and the manual `POST /healthcheck/models/refresh` trigger were added in the release **after** v7.4.0. On v7.4.0 nodes you get the report without those features. The `degraded` status (rate-limited backends) and the consumer-side `SESSION_HEALTH_POLICY` were added later still; on earlier nodes a rate-limited backend reports `unhealthy` with `errorKind: rate_limited`. **v7.11:** untagged / unknown-type models are probed as LLM unless their tags name image/video/audio/music; a failed guessed probe reports `skipped`, not `unhealthy`. The [active.mor.org](/ecosystem/active-status) photograph copies these stamps into ALL / ACTIVE / GATEWAY.
 </Note>
 
 ## What actually runs
@@ -19,7 +19,15 @@ On a schedule (default hourly, plus one sweep immediately at startup), the proxy
 - every model in `models-config.json`, **probed only if it has an active on-chain bid from your wallet**, and
 - every active bid whose model is *missing* from `models-config.json` — capacity you are selling but cannot serve, reported as `no_model_configured`.
 
-An LLM probe is a real, tiny chat completion sent **directly to your backend `apiUrl`** — a randomized arithmetic question ("What is 17+34? Reply with only the number."), graded into `promptCorrect`. Embedding models get a one-input embeddings request. Other model types (TTS, image, video) are not probed and report `skipped`. Results are cached in memory between sweeps.
+An LLM probe is a real, tiny chat completion sent **directly to your backend `apiUrl`** — a randomized arithmetic question ("What is 17+34? Reply with only the number."), graded into `promptCorrect`. Embedding models get a one-input embeddings request. Detection still only knows LLM / embedding / STT / TTS; empty or unrecognised tags are `UNKNOWN`.
+
+Probe policy for `UNKNOWN` and media:
+
+- **Untagged or unknown type, and tags do not name image / video / audio / music** — probe **as LLM** (`typeGuessed`). The report's `modelType` stays `UNKNOWN`.
+- **Tags that name image, video, audio, or music** — `skipped` without a probe (same as STT/TTS).
+- **Guessed LLM probe fails** — status is **`skipped`**, not `unhealthy`. `errorKind` (and `httpStatus` when present) still explain the failure. Tagged LLM / embedding failures remain `unhealthy`. `429` is still `degraded`.
+
+`skipped` is still routable under the consumer default `SESSION_HEALTH_POLICY=permissive`. The hosted API's GATEWAY catalog drops `skipped`. See [Marketplace catalog](/ecosystem/active-status). Results are cached in memory between sweeps.
 
 Two consequences worth internalizing:
 
@@ -86,7 +94,7 @@ curl -s http://localhost:8082/healthcheck | jq '.models'
 | `unhealthy` | Probe failed — `errorKind` and `httpStatus` say why (see below) |
 | `no_bid` | Configured but no active bid; **not probed** |
 | `no_model_configured` | Active bid but no `models-config.json` entry — consumers can open sessions against this bid and get errors |
-| `skipped` | Model type not probeable (TTS, image, video) |
+| `skipped` | Not probed: STT/TTS, or tags that name image/video/audio/music. Also: untagged/unknown type whose **guessed** LLM probe failed (`errorKind` still set). `skipped` stays on the [ACTIVE](/ecosystem/active-status) catalog; GATEWAY drops it. Default consumer policy still routes it. |
 | `tee_unverified` | `tee`-tagged model whose backend TEE attestation failed or never succeeded; **not probed**, and session requests for it are rejected |
 
 For `unhealthy` (and `degraded`) models, the diagnosis is the combination of `errorKind` and `httpStatus`:

--- a/docs/providers/full/quickstart.mdx
+++ b/docs/providers/full/quickstart.mdx
@@ -131,7 +131,7 @@ Run from the working directory (so the relative config and data paths resolve):
 
 Once running:
 
-1. Look up existing models on [active.mor.org/status](https://active.mor.org/status) — prefer bidding on an existing `modelId`.
+1. Look up existing models on [active.mor.org/status](https://active.mor.org/status) — prefer bidding on an existing `modelId`. Layer semantics: [Marketplace catalog](/ecosystem/active-status).
 2. Register via [MyProvider](/providers/full/myprovider-gui) if your admin API is reachable over HTTPS (or use the desktop/local app for HTTP `:8082`); otherwise use Swagger. Full steps: [Register on chain](/providers/full/register-onchain).
 3. Run the [self-checks in Verify your provider setup](/providers/full/verify-setup) before declaring victory.
 

--- a/docs/providers/full/register-onchain.mdx
+++ b/docs/providers/full/register-onchain.mdx
@@ -3,7 +3,7 @@ title: "Register on chain (provider, model, bid)"
 description: "Look up existing models on active.mor.org, register as a provider, bid on a known modelId when possible, and only mint a new model when nothing suitable exists."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.5.0"
+last_verified: "v7.11.0"
 source: "docs/03-provider-offer.md"
 ---
 
@@ -33,14 +33,15 @@ After your proxy-router is running, register on the BASE Diamond contract. **Pre
 
 ## Step 0 — Look up models before you mint
 
-Browse [active.mor.org/status](https://active.mor.org/status) or pull the JSON snapshots:
+Browse [active.mor.org/status](https://active.mor.org/status) or pull the JSON snapshots. Pick the layer — do not treat every file as "the catalog." Semantics: [Marketplace catalog](/ecosystem/active-status). Diagrams: [tech.mor.org/active.html](https://tech.mor.org/active.html).
 
-| URL | Use |
-|-----|-----|
-| [active_models.json](https://active.mor.org/active_models.json) | Routable models (healthy/degraded bids) — start here |
-| [active_bids.json](https://active.mor.org/active_bids.json) | Competing `pricePerSecond` for a model name |
-| [all_models.json](https://active.mor.org/all_models.json) | All non-deleted on-chain models (including ones with no live healthy provider) |
-| [status](https://active.mor.org/status) | Human UI + uptime / min price views |
+| URL | Layer | Use |
+|-----|-------|-----|
+| [active_models.json](https://active.mor.org/active_models.json) | ACTIVE | Polled working set (healthy / degraded / **skipped**) — start here when joining a live listing |
+| [active_bids.json](https://active.mor.org/active_bids.json) | ACTIVE | Competing `pricePerSecond` for a model name |
+| [all_models.json](https://active.mor.org/all_models.json) / [all_bids.json](https://active.mor.org/all_bids.json) | ALL | Non-deleted on-chain records **including failed stamps** (no live healthy provider, unreachable, …) |
+| [gateway_models.json](https://active.mor.org/gateway_models.json) | GATEWAY | Hosted-API input (healthy + degraded + aliases). Not what a C-Node must consume. |
+| [status](https://active.mor.org/status) | Human UI | Uptime / min price views (ACTIVE slice today) |
 
 ```bash
 # Find a model by name (field names are PascalCase in the JSON)

--- a/docs/providers/full/secretvm-quickstart.mdx
+++ b/docs/providers/full/secretvm-quickstart.mdx
@@ -25,7 +25,7 @@ For deeper details (cosign verification, RTMR3 recomputation, attestation manife
 
 ## Step 0: Pick the model you will serve
 
-Before minting anything on chain, see what already exists and at what price:
+Before minting anything on chain, see what already exists and at what price. These curls hit the **ACTIVE** slice ([Marketplace catalog](/ecosystem/active-status)):
 
 ```bash
 curl -sS https://active.mor.org/active_models.json \

--- a/docs/providers/full/verify-setup.mdx
+++ b/docs/providers/full/verify-setup.mdx
@@ -3,7 +3,7 @@ title: "Verify your provider setup"
 description: "Self-check your provider end-to-end after setup: healthcheck, on-chain registration, network discovery, and a real prompt against your bid."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.11.0"
 ---
 
 After [registering](/providers/full/register-onchain) your provider and bid (and a new model only if you had to mint one), you want to know **before any consumer hits you** that everything works. There is no built-in setup wizard yet. This page walks the same five checks the support team uses to verify a provider when someone posts in Discord asking "can you check if my setup is OK?".
@@ -64,7 +64,7 @@ On provider nodes the response also includes a `models` array — the periodic m
 | `unhealthy` | Probe failed — see `errorKind` and `httpStatus` below | Fix the backend; consumers opening a session hit the same failure |
 | `no_bid` | Configured model has no active bid; not probed | Post a bid if you want to sell it |
 | `no_model_configured` | **Active bid exists but the model is missing from `models-config.json`** | Add the model entry or delete the bid — consumers can open sessions against this bid and get errors |
-| `skipped` | Model type other than LLM/embedding; not probed | — |
+| `skipped` | STT/TTS, media tags (image/video/audio/music), or an untagged/unknown type whose guessed LLM probe failed. Not the same as "anything other than LLM." Still routable under default `permissive`. | — unless you need GATEWAY / hosted-API listing |
 
 The self-report has its own operational reference — schedule, tuning, backend impact, and diagnosis recipes — at [Model health self-report](/providers/full/model-health).
 
@@ -129,10 +129,10 @@ If any of these doesn't return your record, the on-chain transaction either fail
 
 ## Step 4 — Network discovery
 
-Two cron-driven dashboards aggregate the marketplace into JSON snapshots. Your provider only shows up here if the cron has reached you successfully **after your registration**:
+[active.mor.org](https://active.mor.org) photographs the marketplace every few minutes into **ALL / ACTIVE / GATEWAY**. Your provider only shows up after a sweep **after your registration**. Layer semantics: [Marketplace catalog](/ecosystem/active-status).
 
 ```bash
-# Active models — populated when the verifier can reach your provider's :3333 and ping the model
+# ACTIVE working set — skipped / degraded / healthy (what most C-Node apps consume)
 curl -sS https://active.mor.org/active_models.json \
   | jq --arg p "0xYOUR_PROVIDER" '
       .models[]
@@ -140,15 +140,23 @@ curl -sS https://active.mor.org/active_models.json \
       | {Name, Id, Tags, bidDetail}
     '
 
-# Active bids — same, but for bids
+# ACTIVE bids
 curl -sS https://active.mor.org/active_bids.json \
   | jq --arg p "0xYOUR_PROVIDER" '
       .bids[]
       | select(.Provider | ascii_downcase == ($p | ascii_downcase))
     '
+
+# ALL — same sweep including failed stamps (unreachable, unreported, unhealthy, …)
+curl -sS https://active.mor.org/all_bids.json \
+  | jq --arg p "0xYOUR_PROVIDER" '
+      .bids[]
+      | select(.Provider | ascii_downcase == ($p | ascii_downcase))
+      | {ModelName, Id, health}
+    '
 ```
 
-If your bid is on chain (Step 3) but **not** in `active_bids.json`, it means the verifier could reach the chain but **could not reach your `:3333`**. Re-check Step 2.
+If your bid is on chain (Step 3) but **not** in `active_bids.json`, look at `all_bids.json` for the stamp. `unreachable` / `unreported` usually means the sweep could not reach your `:3333` or got no `models[]` — re-check Step 2. `unhealthy` / `no_model_configured` is a self-report problem ([model health](/providers/full/model-health)). GATEWAY (`gateway_models.json`) additionally drops `skipped`; that is the hosted-API input, not a C-Node requirement.
 
 The dashboards refresh on a schedule (a few minutes); give it time before concluding it failed.
 

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -50,6 +50,12 @@ MOR_TOKEN_ADDRESS=0x7431aDa8a591C955a994a21710752EF9b882b8e3
 # Private key for signing transactions; if not set, the system keychain will be used
 WALLET_PRIVATE_KEY=
 
+# IPFS (optional). Empty IPFS_MULTADDR = disabled — there is no localhost:5001
+# default (that string is not a multiaddr). Operators running Kubo should set
+# a real multiaddr, e.g. /ip4/127.0.0.1/tcp/5001. The desktop already does.
+IPFS_MULTADDR=
+IPFS_DISABLED=false
+
 # Logging Configurations
 # Enable colored logging
 LOG_COLOR=false
@@ -83,7 +89,8 @@ MODELS_CONFIG_CONTENT='{"$schema":"./internal/config/models-config-schema.json",
 RATING_CONFIG_PATH=./rating-config.json
 # Provider model health self-checks: periodically probe each configured model
 # that has an active bid from this wallet (LLM: arithmetic test prompt,
-# embedding: embeddings request) and expose sanitized results in GET /healthcheck.
+# embedding: embeddings request). Untagged/unknown types are LLM-probed unless
+# tags name image/video/audio/music; a failed guessed probe reports skipped.
 # Also flags active bids whose model is missing from models-config.json
 # (no_model_configured).
 # Set to true to disable the loop entirely.

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -3,7 +3,7 @@ title: "Env: proxy-router"
 description: "Every environment variable consumed by the proxy-router, with mainnet/testnet defaults and explicit precedence rules where two variables overlap."
 audience: ["provider-full", "provider-resale", "prosumer", "developer"]
 product: ["proxy-router"]
-last_verified: "2026-08-24"
+last_verified: "2026-09-09"
 source: "docs/proxy-router.all.env"
 ---
 
@@ -177,7 +177,7 @@ For exact defaults check the source of truth ([`config.go`](https://github.com/M
 
 ## Model health self-checks (provider)
 
-On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request, and other model types are skipped. The report covers the whole ecosystem of bids and configured models — active bids whose model is missing from `models-config.json` are flagged as `no_model_configured` (capacity being sold with no backend to serve it). The cached per-model results (on-chain `modelId` and registered model name, `bidId`, status, `errorKind` plus upstream `httpStatus` on failure, `lastHealthy` epoch, latency, prompt correctness — never the private `models-config.json` `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`, in the `network.ping` (pong) response on the `:3333` MOR RPC port, and in `POST /proxy/provider/ping`, so consumers can see a provider's model health before opening a session. Full operational guide: [Model health self-report](/providers/full/model-health).
+On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request. Untagged / unknown-type models are probed as LLM unless their tags name image/video/audio/music; a failed guessed probe reports `skipped` (with `errorKind`), not `unhealthy`. STT/TTS and media-tagged models are skipped without a probe. The report covers the whole ecosystem of bids and configured models — active bids whose model is missing from `models-config.json` are flagged as `no_model_configured` (capacity being sold with no backend to serve it). The cached per-model results (on-chain `modelId` and registered model name, `bidId`, status, `errorKind` plus upstream `httpStatus` on failure, `lastHealthy` epoch, latency, prompt correctness — never the private `models-config.json` `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`, in the `network.ping` (pong) response on the `:3333` MOR RPC port, and in `POST /proxy/provider/ping`, so consumers can see a provider's model health before opening a session. The [active.mor.org](/ecosystem/active-status) sweep copies these stamps into ALL / ACTIVE / GATEWAY. Full operational guide: [Model health self-report](/providers/full/model-health).
 
 | Variable | Default | Notes |
 |----------|---------|-------|
@@ -216,6 +216,15 @@ These are only consulted when at least one model in the marketplace is `tee`-tag
 | `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | `1h` | How often the proxy-router re-downloads the artifact registry |
 
 See [TEE overview](/concepts/tee-overview) and [TEE reference](/providers/full/tee-reference).
+
+## IPFS (optional)
+
+The proxy-router talks to a local Kubo API only when you set a real **multiaddr**. Unset `IPFS_MULTADDR` means IPFS is **disabled** — that is the headless default since v7.11. There is **no** `localhost:5001` default (that string is not a multiaddr and used to log ERROR on every boot). The bundled desktop already sets `/ip4/127.0.0.1/tcp/5001` when it runs Kubo.
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `IPFS_MULTADDR` | *(empty — disabled)* | Kubo API multiaddr, e.g. `/ip4/127.0.0.1/tcp/5001`. Invalid values log a warning and disable IPFS. |
+| `IPFS_DISABLED` | `false` | Set `true` to force-disable even when `IPFS_MULTADDR` is set. |
 
 ## System tuning (optional sysctl tweaks)
 

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -3,7 +3,7 @@ title: "Glossary"
 description: "Canonical, agent-friendly definitions of Morpheus terms."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.9.0"
+last_verified: "v7.11.0"
 ---
 
 LLM-friendly definitions — short, opinionated, and consistent across the rest of the docs. If a term here disagrees with anything elsewhere on this site, the rest of the site is wrong; file an issue.
@@ -46,8 +46,9 @@ LLM-friendly definitions — short, opinionated, and consistent across the rest 
 | **Inference API / API Gateway** | Hosted OpenAI-compatible HTTPS gateway built on top of Morpheus. Base URL: `https://api.mor.org/api/v1`. Docs at [apidocs.mor.org](https://apidocs.mor.org). For users who don't want to run their own node. |
 | **Morpheus Chat App / `app.mor.org`** | Hosted browser-based consumer chat UI, powered by the hosted Inference API Gateway. |
 | **`gitbook.mor.org`** | Broader Morpheus documentation hub. Supports an `?ask=<question>` query parameter that returns natural-language answers + sources — useful for AI agents. See [LLM cheatsheet](/ai/llm-prompt-cheatsheet#dynamic-querying-of-the-broader-morpheus-docs). |
-| **`active.mor.org`** | Live marketplace state — status, active models, active bids. |
-| **`tech.mor.org`** | Calculators, sessions, TEE, throughput explainers. |
+| **`active.mor.org`** | Shared ~5-minute photograph of the marketplace. Applications pick **ALL**, **ACTIVE**, or **GATEWAY** — see [Marketplace catalog](/ecosystem/active-status). Live files; never invent counts. Explainer: [tech.mor.org/active.html](https://tech.mor.org/active.html). |
+| **ALL / ACTIVE / GATEWAY** | Three views of the same active.mor.org sweep. ALL = honest stamps including failures. ACTIVE = polled working set including `skipped`. GATEWAY = healthy + degraded + aliases (hosted API input). |
+| **`tech.mor.org`** | Illustrated explainers: catalog funnel, session wallet checker, TEE, calculator, throughput. Index: [tech.mor.org](/ecosystem/tech-mor-org). |
 | **MyProvider** | Hosted operator GUI at https://myprovider.mor.org — Basic Auth to your proxy-router for provider/bid/config management (not a browser wallet). |
 | **NodeNeo** | Cross-platform consumer experience at https://nodeneo.io. |
 | **Everclaw** | Agent project at https://everclaw.xyz, with a Morpheus skill for OpenClaw. |

--- a/proxy-router/.env.example
+++ b/proxy-router/.env.example
@@ -48,6 +48,11 @@ PROXY_FORWARD_CHAT_CONTEXT=false
 PROXY_STORAGE_PATH=./data/
 LOG_COLOR=true
 
+# OPTIONAL — IPFS. Unset = disabled (v7.11+). Do not set host:port; use a
+# multiaddr if you run Kubo, e.g. IPFS_MULTADDR=/ip4/127.0.0.1/tcp/5001
+# IPFS_MULTADDR=
+# IPFS_DISABLED=false
+
 # OPTIONAL 
 # Log Levels: error, warn, info, debug 
 LOG_LEVEL_APP=warn


### PR DESCRIPTION
## Summary
- Document `active.mor.org` as a builder surface: pick **ALL / ACTIVE / GATEWAY** from the same sweep; live files stay on active.mor.org; illustrated explainer is [tech.mor.org/active.html](https://tech.mor.org/active.html). Hosted API consumes GATEWAY (`gateway_models.json`), then its allowlist — not `active_models.json`.
- Align nodedocs with what is on `test` for expected v7.11: untagged models are LLM-probed (failed guess → `skipped`, not `unhealthy`); empty `IPFS_MULTADDR` disables IPFS with no ERROR; leftover stake-claim copy points at `POST /blockchain/stakes/withdraw`.
- Verify-setup Step 4 now says: missing from ACTIVE → read ALL for the stamp.

## Test plan
- [ ] Mintlify nav: catalog page appears under Concepts and Ecosystem
- [ ] [Marketplace catalog](https://nodedocs.mor.org/ecosystem/active-status) (after nodedocs.dev deploy) names ALL/ACTIVE/GATEWAY files and links tech.mor.org/active.html
- [ ] Model-health / verify-setup no longer say “anything other than LLM is skipped”
- [ ] Env page documents `IPFS_MULTADDR` / `IPFS_DISABLED`
- [ ] Inference API overview does not equate `active_models.json` with `api.mor.org`


Made with [Cursor](https://cursor.com)