### PR TITLE
revert: keep .env.example out of the v7.11 docs promote

### DIFF
--- a/proxy-router/.env.example
+++ b/proxy-router/.env.example
@@ -48,11 +48,6 @@ PROXY_FORWARD_CHAT_CONTEXT=false
 PROXY_STORAGE_PATH=./data/
 LOG_COLOR=true
 
-# OPTIONAL — IPFS. Unset = disabled (v7.11+). Do not set host:port; use a
-# multiaddr if you run Kubo, e.g. IPFS_MULTADDR=/ip4/127.0.0.1/tcp/5001
-# IPFS_MULTADDR=
-# IPFS_DISABLED=false
-
 # OPTIONAL 
 # Log Levels: error, warn, info, debug 
 LOG_LEVEL_APP=warn


### PR DESCRIPTION
## Summary
- Restores `proxy-router/.env.example` to the pre-#877 file so the net `dev` → `test` diff has **no** `proxy-router/` path.
- CI treats any `proxy-router/**` change as a router rebuild. The IPFS comment block from #877 would have forced another full deploy.
- Operator docs for empty `IPFS_MULTADDR` stay in `docs/reference/env-proxy-router.mdx` and `docs/proxy-router.all.env`.

## Test plan
- [ ] `git diff origin/test...HEAD -- proxy-router/` is empty after this lands on `dev` (aside from whatever else is already on `dev` vs `test` from #865/#873/#866)
- [ ] This PR’s own diff is only `proxy-router/.env.example` (5 comment lines removed)


Made with [Cursor](https://cursor.com)