### PR TITLE
fix(proxyctl): retry the startup balance read instead of exiting on a transient RPC 429

### DIFF
--- a/proxy-router/internal/proxyctl/proxyctl.go
+++ b/proxy-router/internal/proxyctl/proxyctl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi"
@@ -37,6 +38,15 @@ const (
 const (
 	MORDecimals = 18
 	ETHDecimals = 18
+)
+
+const (
+	// balanceRetryAttempts is how many times the startup balance read is tried
+	// before the proxy gives up and stops.
+	balanceRetryAttempts = 5
+	// balanceRetryDelay is the delay before the second attempt. It doubles
+	// after every further failure.
+	balanceRetryDelay = 2 * time.Second
 )
 
 var (
@@ -163,7 +173,16 @@ func (p *Proxy) run(ctx context.Context, prKey lib.HexString) error {
 	}
 	p.log.Infof("Wallet address: %s", walletAddr.String())
 
-	ethBalance, morBalance, err := p.blockchainService.GetBalance(ctx)
+	// The eth node may rate-limit this read, most often because the model
+	// pre-flight in cmd/main.go has just issued one call per configured model
+	// against the same endpoint. That is transient, so retry rather than
+	// stopping the proxy.
+	var ethBalance, morBalance *big.Int
+	err = retryWithBackoff(ctx, balanceRetryAttempts, balanceRetryDelay, p.log, "balance read", func() error {
+		var err error
+		ethBalance, morBalance, err = p.blockchainService.GetBalance(ctx)
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -322,4 +341,35 @@ func formatMOR(n *big.Int) string {
 
 func formatETH(n *big.Int) string {
 	return formatDecimal(n, ETHDecimals) + " ETH"
+}
+
+// retryWithBackoff calls fn until it returns nil, ctx is done, or attempts are
+// exhausted, doubling delay after each failure. It returns the last error from
+// fn, or ctx.Err() if the context ended first.
+func retryWithBackoff(ctx context.Context, attempts int, delay time.Duration, log lib.ILogger, what string, fn func() error) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if attempt == attempts {
+			break
+		}
+
+		log.Warnf("%s failed, retrying (%d/%d) in %s: %s", what, attempt, attempts, delay, lastErr)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+		delay *= 2
+	}
+
+	return fmt.Errorf("%s failed after %d attempts: %w", what, attempts, lastErr)
 }

--- a/proxy-router/internal/proxyctl/proxyctl_test.go
+++ b/proxy-router/internal/proxyctl/proxyctl_test.go
@@ -1,0 +1,159 @@
+package proxyctl
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+// rateLimitErr is the shape the eth node returns when it throttles a call.
+var rateLimitErr = errors.New(`429 Too Many Requests: {"jsonrpc":"2.0","error":{"code":-32016,"message":"over rate limit"},"id":37}`)
+
+func TestRetryWithBackoff(t *testing.T) {
+	tests := []struct {
+		name        string
+		attempts    int
+		failures    int // how many leading calls fail before success
+		alwaysFails bool
+		wantCalls   int
+		wantErr     bool
+		wantErrIsFn bool // the returned error should wrap the error fn produced
+	}{
+		{
+			name:      "succeeds on first attempt",
+			attempts:  5,
+			failures:  0,
+			wantCalls: 1,
+		},
+		{
+			name:      "succeeds after transient rate limit",
+			attempts:  5,
+			failures:  1,
+			wantCalls: 2,
+		},
+		{
+			name:      "succeeds on the final allowed attempt",
+			attempts:  3,
+			failures:  2,
+			wantCalls: 3,
+		},
+		{
+			name:        "gives up after attempts are exhausted",
+			attempts:    3,
+			alwaysFails: true,
+			wantCalls:   3,
+			wantErr:     true,
+			wantErrIsFn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			fn := func() error {
+				calls++
+				if tt.alwaysFails || calls <= tt.failures {
+					return rateLimitErr
+				}
+				return nil
+			}
+
+			err := retryWithBackoff(context.Background(), tt.attempts, time.Millisecond, lib.NewTestLogger(), "balance read", fn)
+
+			if calls != tt.wantCalls {
+				t.Errorf("fn called %d times, want %d", calls, tt.wantCalls)
+			}
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tt.wantErrIsFn && !errors.Is(err, rateLimitErr) {
+				t.Errorf("error %v does not wrap the error returned by fn", err)
+			}
+		})
+	}
+}
+
+// A 429 must not become a fatal error while retries remain. This is the
+// regression the startup restart loop came from.
+func TestRetryWithBackoffToleratesRateLimit(t *testing.T) {
+	calls := 0
+	fn := func() error {
+		calls++
+		if calls < 3 {
+			return rateLimitErr
+		}
+		return nil
+	}
+
+	if err := retryWithBackoff(context.Background(), 5, time.Millisecond, lib.NewTestLogger(), "balance read", fn); err != nil {
+		t.Fatalf("rate limit should have been retried, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("fn called %d times, want 3", calls)
+	}
+}
+
+func TestRetryWithBackoffStopsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	fn := func() error {
+		calls++
+		cancel() // the proxy is shutting down mid-flight
+		return rateLimitErr
+	}
+
+	err := retryWithBackoff(ctx, 5, time.Hour, lib.NewTestLogger(), "balance read", fn)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times after cancellation, want 1", calls)
+	}
+}
+
+// The retry must not outlive a context deadline, so a shutdown is not held up
+// by a long backoff delay.
+func TestRetryWithBackoffRespectsDeadlineDuringDelay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	fn := func() error { return rateLimitErr }
+
+	start := time.Now()
+	err := retryWithBackoff(ctx, 5, time.Hour, lib.NewTestLogger(), "balance read", fn)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("retry waited %s, should have returned at the deadline", elapsed)
+	}
+}
+
+func TestRetryWithBackoffDelayGrows(t *testing.T) {
+	var timestamps []time.Time
+	fn := func() error {
+		timestamps = append(timestamps, time.Now())
+		return rateLimitErr
+	}
+
+	_ = retryWithBackoff(context.Background(), 4, 10*time.Millisecond, lib.NewTestLogger(), "balance read", fn)
+
+	if len(timestamps) != 4 {
+		t.Fatalf("fn called %d times, want 4", len(timestamps))
+	}
+	first := timestamps[1].Sub(timestamps[0])
+	last := timestamps[3].Sub(timestamps[2])
+	if last <= first {
+		t.Errorf("delay did not grow: first gap %s, last gap %s", first, last)
+	}
+}


### PR DESCRIPTION
Fixes #881.

@nomadicrogue you said on the issue that you don't disagree we could use some back-off on that initial RPC work. This is that, kept as small as I could make it.

## The change

`Proxy.run` reads the wallet balance at `proxyctl.go:166` and returns the error bare. A 429 there propagates to `"proxy stopped with error"`, then `"App exited due to"`, and the process exits 1. With `Restart=always` that is a restart loop, because each restart re-issues the burst that tripped the limit.

The model pre-flight loop in `cmd/main.go:352` hits the same endpoint moments earlier, one call per configured model, and already tolerates a 429 by logging and continuing. The balance read is the only call on that path that treats it as fatal.

So the read is now wrapped in `retryWithBackoff`: 5 attempts, 2s doubling to 32s, ~30s worst case before it gives up and stops as it does today. It returns `ctx.Err()` if the proxy is shutting down, so a pending backoff delay cannot hold up a stop.

I followed the bounded-retry shape already in the repo (`LogWatcherPolling.retry`, `ExplorerClient.doRequestRetry`) rather than adding a dependency. The helper is unexported and takes `fn func() error`, so the other unretried startup reads can adopt it later if you want.

## On the endpoint

Agreed that `mainnet.base.org` is the wrong choice for a provider, and I've moved off it. Two reasons I think the retry still earns its place:

1. Any provider that rate-limits does this, paid ones included during a burst. I've since tripped an Alchemy limit the same way.
2. The shipped default is still a public endpoint, so a new provider meets this on first run, before they've read the recommendation. Either the default changes or the call retries. This PR is the cheaper of the two.

Happy to add a docs note on `ETH_NODE_ADDRESS` in the same PR if you'd prefer both.

## Tests

`internal/proxyctl/proxyctl_test.go` is new (the package had no test file). Table-driven over the retry helper, plus cases for: a 429 tolerated while attempts remain, a cancelled context stopping immediately, a context deadline honoured during a long backoff delay, and the delay growing between attempts.

```
go test ./internal/proxyctl/ -count=1
ok  github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/proxyctl  0.127s
    TestRetryWithBackoff (4 subtests)           PASS
    TestRetryWithBackoffToleratesRateLimit      PASS
    TestRetryWithBackoffStopsOnCancelledContext PASS
    TestRetryWithBackoffRespectsDeadlineDuringDelay PASS
    TestRetryWithBackoffDelayGrows              PASS
```

`go build ./...` clean, `go vet ./internal/proxyctl/` clean, `gofmt -l ./internal/proxyctl/` empty. Ran on `golang:1.25` matching `go.mod`.

Full-suite check: `go test ./... -count=1 -vet=off` gives the same failure set on this branch as on a clean `dev` checkout, which is `internal/repositories/keychain` (`TestGetSet`, wants an OS keychain), `proxy-router/test` (build failure, `NewAiEngine` signature drift and undefined symbols in `httphandlers_test.go`), and flaky `internal/attestation` plus `blockchainapi/TestRating`. No new failures from this change. I have the toolchain properly this time, so say the word if you want anything else run.
