### PR TITLE
fix(proxy-router): debit agent allowance before broadcast

### DIFF
--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -377,14 +377,17 @@ func (s *BlockchainService) rateBids(bidIds [][32]byte, bids []m.IBidStorageBid,
 func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalSig []byte, stake *big.Int, directPayment bool, agentUsername string, isTee bool) (common.Hash, error) {
 	log := s.requestLog(ctx)
 
-	var isAgent bool
-	if s.authConfig != nil {
-		var err error
-		isAgent, err = s.authConfig.IsAllowanceEnough(agentUsername, s.morTokenAddr.Hex(), stake)
-		if err != nil {
-			return common.Hash{}, lib.WrapError(ErrAgentUserAllowance, err)
-		}
+	held, holdAmount, err := s.holdAgentAllowance(agentUsername, s.morTokenAddr.Hex(), stake)
+	if err != nil {
+		return common.Hash{}, err
 	}
+	keepHold := false
+	defer func() {
+		if held && !keepHold {
+			s.releaseAgentAllowance(agentUsername, s.morTokenAddr.Hex(), holdAmount)
+		}
+	}()
+	isAgent := held
 
 	prKey, err := s.privateKey.GetPrivateKey()
 	if err != nil {
@@ -479,27 +482,26 @@ func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalS
 		}
 	}
 	if lastOpenErr != nil {
+		if errors.Is(lastOpenErr, lib.ErrEscalationFailed) {
+			keepHold = true
+		}
 		s.handleTxError(ctx, addr, lastOpenErr)
 		return common.Hash{}, lib.WrapError(ErrSendTx, classifyOpenSessionError("open session failed", lastOpenErr))
+	}
+
+	// Broadcast succeeded. Keep the agent debit even if receipt parsing fails.
+	keepHold = true
+	if isAgent && s.authConfig != nil {
+		err = s.authConfig.AuthStorage.SetAgentTx(sessionReceipt.TxHash.Hex(), agentUsername, sessionReceipt.BlockNumber)
+		if err != nil {
+			log.Errorf("failed to set agent tx: %s", err)
+		}
 	}
 
 	// Parse session info from receipt
 	sessionID, _, _, err := s.sessionRouter.ParseOpenSessionReceipt(ctx, sessionReceipt)
 	if err != nil {
 		return common.Hash{}, lib.WrapError(ErrSendTx, fmt.Errorf("parse session receipt failed: %w", err))
-	}
-
-	if isAgent && s.authConfig != nil {
-		amountBigInt := lib.BigInt{Int: *stake}
-		err = s.authConfig.DecreaseAllowance(agentUsername, s.morTokenAddr.Hex(), amountBigInt)
-		if err != nil {
-			log.Errorf("failed to decrease allowance: %s", err)
-			return common.Hash{}, err
-		}
-		err = s.authConfig.AuthStorage.SetAgentTx(sessionReceipt.TxHash.Hex(), agentUsername, sessionReceipt.BlockNumber)
-		if err != nil {
-			log.Errorf("failed to set agent tx: %s", err)
-		}
 	}
 
 	// Poll until the session is visible on-chain (handles RPC propagation lag).
@@ -890,14 +892,16 @@ func (s *BlockchainService) WithdrawUserStakes(ctx context.Context, iterations u
 }
 
 func (s *BlockchainService) SendETH(ctx context.Context, to common.Address, amount *big.Int, agentUsername string) (common.Hash, error) {
-	var shouldDecrease bool
-	if s.authConfig != nil {
-		var err error
-		shouldDecrease, err = s.authConfig.IsAllowanceEnough(agentUsername, "eth", amount)
-		if err != nil {
-			return common.Hash{}, lib.WrapError(ErrAgentUserAllowance, err)
-		}
+	held, holdAmount, err := s.holdAgentAllowance(agentUsername, "eth", amount)
+	if err != nil {
+		return common.Hash{}, err
 	}
+	keepHold := false
+	defer func() {
+		if held && !keepHold {
+			s.releaseAgentAllowance(agentUsername, "eth", holdAmount)
+		}
+	}()
 
 	signedTx, err := s.createSignedTransaction(ctx, &types.DynamicFeeTx{
 		To:    &to,
@@ -912,19 +916,15 @@ func (s *BlockchainService) SendETH(ctx context.Context, to common.Address, amou
 		return common.Hash{}, lib.WrapError(ErrSendTx, err)
 	}
 
+	keepHold = true
+
 	// Wait for tx to be mined with timeout
 	receipt, err := lib.WaitMinedWithTimeout(ctx, s.ethClient, signedTx, lib.DefaultTxMineTimeout)
 	if err != nil {
 		return common.Hash{}, lib.WrapError(ErrWaitMined, err)
 	}
 
-	if shouldDecrease && s.authConfig != nil {
-		amountBigInt := lib.BigInt{Int: *amount}
-		err = s.authConfig.DecreaseAllowance(agentUsername, "eth", amountBigInt)
-		if err != nil {
-			s.log.Errorf("failed to decrease allowance: %s", err)
-			return common.Hash{}, err
-		}
+	if held && s.authConfig != nil {
 		s.authConfig.AuthStorage.SetAgentTx(signedTx.Hash().Hex(), agentUsername, receipt.BlockNumber)
 	}
 
@@ -997,14 +997,16 @@ func (s *BlockchainService) createSignedTransaction(ctx context.Context, txdata 
 }
 
 func (s *BlockchainService) SendMOR(ctx context.Context, to common.Address, amount *big.Int, agentUsername string) (common.Hash, error) {
-	var shouldDecrease bool
-	if s.authConfig != nil {
-		var err error
-		shouldDecrease, err = s.authConfig.IsAllowanceEnough(agentUsername, s.morTokenAddr.Hex(), amount)
-		if err != nil {
-			return common.Hash{}, lib.WrapError(ErrAgentUserAllowance, err)
-		}
+	held, holdAmount, err := s.holdAgentAllowance(agentUsername, s.morTokenAddr.Hex(), amount)
+	if err != nil {
+		return common.Hash{}, err
 	}
+	keepHold := false
+	defer func() {
+		if held && !keepHold {
+			s.releaseAgentAllowance(agentUsername, s.morTokenAddr.Hex(), holdAmount)
+		}
+	}()
 
 	prKey, err := s.privateKey.GetPrivateKey()
 	if err != nil {
@@ -1017,17 +1019,14 @@ func (s *BlockchainService) SendMOR(ctx context.Context, to common.Address, amou
 	}
 
 	tx, receipt, err := s.morToken.Transfer(transactOpt, to, amount)
+	if tx != nil {
+		keepHold = true
+	}
 	if err != nil {
 		return common.Hash{}, lib.WrapError(ErrSendTx, err)
 	}
 
-	if shouldDecrease && s.authConfig != nil {
-		amountBigInt := lib.BigInt{Int: *amount}
-		err = s.authConfig.DecreaseAllowance(agentUsername, s.morTokenAddr.Hex(), amountBigInt)
-		if err != nil {
-			s.log.Errorf("failed to decrease allowance: %s", err)
-			return common.Hash{}, err
-		}
+	if held && s.authConfig != nil {
 		err = s.authConfig.AuthStorage.SetAgentTx(tx.Hash().Hex(), agentUsername, receipt.BlockNumber)
 		if err != nil {
 			s.log.Errorf("failed to set agent tx: %s", err)
@@ -1035,6 +1034,34 @@ func (s *BlockchainService) SendMOR(ctx context.Context, to common.Address, amou
 	}
 
 	return tx.Hash(), nil
+}
+
+func (s *BlockchainService) holdAgentAllowance(username string, token string, amount *big.Int) (bool, lib.BigInt, error) {
+	var holdAmount lib.BigInt
+	if s.authConfig == nil {
+		return false, holdAmount, nil
+	}
+	enough, err := s.authConfig.IsAllowanceEnough(username, token, amount)
+	if err != nil {
+		return false, holdAmount, lib.WrapError(ErrAgentUserAllowance, err)
+	}
+	if !enough {
+		return false, holdAmount, nil
+	}
+	holdAmount = lib.BigInt{Int: *new(big.Int).Set(amount)}
+	if err := s.authConfig.DecreaseAllowance(username, token, holdAmount); err != nil {
+		return false, holdAmount, lib.WrapError(ErrAgentUserAllowance, err)
+	}
+	return true, holdAmount, nil
+}
+
+func (s *BlockchainService) releaseAgentAllowance(username string, token string, amount lib.BigInt) {
+	if s.authConfig == nil {
+		return
+	}
+	if err := s.authConfig.IncreaseAllowance(username, token, amount); err != nil {
+		s.log.Errorf("failed to restore agent allowance: %s", err)
+	}
 }
 
 func (s *BlockchainService) GetAllowance(ctx context.Context, spender common.Address) (*big.Int, error) {

--- a/proxy-router/internal/repositories/registries/mor_token.go
+++ b/proxy-router/internal/repositories/registries/mor_token.go
@@ -125,7 +125,7 @@ func (g *MorToken) Transfer(ctx *bind.TransactOpts, to common.Address, value *bi
 	// Wait for the transaction receipt with timeout
 	receipt, err := lib.WaitMinedWithTimeout(ctx.Context, g.client, tx, lib.DefaultTxMineTimeout)
 	if err != nil {
-		return nil, nil, err
+		return tx, nil, err
 	}
 	return tx, receipt, nil
 }

--- a/proxy-router/internal/storages/auth_storage.go
+++ b/proxy-router/internal/storages/auth_storage.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	authRequestPrefix      = "auth_request"
-	allowanceRequestPrefix = "allowance_request"
-	agentTxPrefix          = "agent_tx"
+	authRequestPrefix        = "auth_request"
+	allowanceRequestPrefix   = "allowance_request"
+	agentTxPrefix            = "agent_tx"
+	allowanceConflictRetries = 32
 )
 
 type AuthStorage struct {
@@ -156,6 +157,82 @@ func (s *AuthStorage) ConfirmOrDeclineAllowanceRequest(username string, token st
 
 	key := formatKey(allowanceRequestPrefix, username, token)
 	return s.db.Delete(key)
+}
+
+// DecreaseAllowance subtracts amount from the token allowance inside one Badger
+// transaction. It fails closed if the user, token, or remaining balance is missing.
+func (s *AuthStorage) DecreaseAllowance(username string, token string, amount lib.BigInt) error {
+	return s.adjustAllowance(username, token, amount, false)
+}
+
+// IncreaseAllowance adds amount to the token allowance inside one Badger transaction.
+func (s *AuthStorage) IncreaseAllowance(username string, token string, amount lib.BigInt) error {
+	return s.adjustAllowance(username, token, amount, true)
+}
+
+func (s *AuthStorage) adjustAllowance(username string, token string, amount lib.BigInt, increase bool) error {
+	token = strings.ToLower(token)
+	if amount.Sign() < 0 {
+		return fmt.Errorf("allowance adjustment must be non-negative")
+	}
+
+	key := formatKey(authRequestPrefix, username)
+	var last error
+	for attempt := 0; attempt < allowanceConflictRetries; attempt++ {
+		last = s.adjustAllowanceOnce(key, username, token, amount, increase)
+		if last == nil || !errors.Is(last, badger.ErrConflict) {
+			return last
+		}
+	}
+	return last
+}
+
+func (s *AuthStorage) adjustAllowanceOnce(key []byte, username string, token string, amount lib.BigInt, increase bool) error {
+	return s.db.RunInTransaction(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if err != nil {
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				return fmt.Errorf("allowance not found")
+			}
+			return fmt.Errorf("error reading agent user %s for allowance update: %w", username, err)
+		}
+
+		requestJson, err := item.ValueCopy(nil)
+		if err != nil {
+			return fmt.Errorf("error copying agent user value for %s: %w", username, err)
+		}
+
+		request := &AgentUser{}
+		if err := json.Unmarshal(requestJson, request); err != nil {
+			return fmt.Errorf("error unmarshaling agent user %s: %w", username, err)
+		}
+
+		if request.Allowances == nil {
+			request.Allowances = make(map[string]lib.BigInt)
+		}
+
+		current, exists := request.Allowances[token]
+		if !exists && !increase {
+			return fmt.Errorf("allowance not found")
+		}
+
+		next := new(big.Int).Set(&current.Int)
+		if increase {
+			next.Add(next, &amount.Int)
+		} else {
+			if next.Cmp(&amount.Int) < 0 {
+				return fmt.Errorf("not enough allowance")
+			}
+			next.Sub(next, &amount.Int)
+		}
+		request.Allowances[token] = lib.BigInt{Int: *next}
+
+		updatedJson, err := json.Marshal(request)
+		if err != nil {
+			return err
+		}
+		return txn.Set(key, updatedJson)
+	})
 }
 
 // SetAllowance atomically reads the agent user, updates the allowance, and writes back

--- a/proxy-router/internal/storages/auth_storage_test.go
+++ b/proxy-router/internal/storages/auth_storage_test.go
@@ -2,10 +2,92 @@ package storages
 
 import (
 	"math/big"
+	"sync"
 	"testing"
 
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDecreaseAllowanceRejectsWhenBalanceIsTooSmall(t *testing.T) {
+	authStorage := agentAllowanceFixture(t, "100")
+
+	err := authStorage.DecreaseAllowance("testuser", "eth", bigInt("100"))
+	require.NoError(t, err)
+
+	err = authStorage.DecreaseAllowance("testuser", "eth", bigInt("1"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not enough allowance")
+
+	user, err := authStorage.GetAgentUser("testuser")
+	require.NoError(t, err)
+	eth := user.Allowances["eth"]
+	require.Equal(t, "0", eth.String())
+}
+
+func TestDecreaseAllowanceIsAtomicAcrossOverlappingDebits(t *testing.T) {
+	authStorage := agentAllowanceFixture(t, "10")
+
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		successes int
+	)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := authStorage.DecreaseAllowance("testuser", "eth", bigInt("1"))
+			if err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 10, successes)
+	user, err := authStorage.GetAgentUser("testuser")
+	require.NoError(t, err)
+	eth := user.Allowances["eth"]
+	require.Equal(t, "0", eth.String())
+}
+
+func TestIncreaseAllowanceRestoresAHeldDebit(t *testing.T) {
+	authStorage := agentAllowanceFixture(t, "5")
+
+	require.NoError(t, authStorage.DecreaseAllowance("testuser", "eth", bigInt("5")))
+	require.NoError(t, authStorage.IncreaseAllowance("testuser", "eth", bigInt("5")))
+
+	user, err := authStorage.GetAgentUser("testuser")
+	require.NoError(t, err)
+	eth := user.Allowances["eth"]
+	require.Equal(t, "5", eth.String())
+}
+
+func agentAllowanceFixture(t *testing.T, amount string) *AuthStorage {
+	t.Helper()
+	db := NewTestStorage()
+	authStorage := NewAuthStorage(db)
+	err := authStorage.AddAuthRequest(&AgentUser{
+		Username: "testuser",
+		Allowances: map[string]lib.BigInt{
+			"eth": bigInt(amount),
+		},
+		IsConfirmed: true,
+	})
+	require.NoError(t, err)
+	return authStorage
+}
+
+func bigInt(value string) lib.BigInt {
+	n, ok := new(big.Int).SetString(value, 10)
+	if !ok {
+		panic("invalid fixture amount")
+	}
+	return lib.BigInt{Int: *n}
+}
 
 func TestGetAgentTxOrder(t *testing.T) {
 	authStorage := agentTxsFixture(t)

--- a/proxy-router/internal/system/auth.go
+++ b/proxy-router/internal/system/auth.go
@@ -563,22 +563,13 @@ func (cfg *HTTPAuthConfig) RevokeAllowance(username string, token string) error 
 }
 
 func (cfg *HTTPAuthConfig) DecreaseAllowance(username string, token string, amount lib.BigInt) error {
-	agentUser, err := cfg.AuthStorage.GetAgentUser(username)
-	if err != nil {
-		return fmt.Errorf("error reading agent user: %w", err)
-	}
-	if agentUser == nil {
-		return fmt.Errorf("allowance not found")
-	}
-
 	token = strings.ToLower(token)
-	allowance, exists := agentUser.Allowances[token]
-	if !exists {
-		return fmt.Errorf("allowance not found")
-	}
+	return cfg.AuthStorage.DecreaseAllowance(username, token, amount)
+}
 
-	allowance.Sub(&allowance.Int, &amount.Int)
-	return cfg.AuthStorage.SetAllowance(username, token, allowance)
+func (cfg *HTTPAuthConfig) IncreaseAllowance(username string, token string, amount lib.BigInt) error {
+	token = strings.ToLower(token)
+	return cfg.AuthStorage.IncreaseAllowance(username, token, amount)
 }
 
 func (cfg *HTTPAuthConfig) GetAgentTxs(username string, cursor []byte, limit uint) ([]string, []byte, error) {


### PR DESCRIPTION
## Summary

- Debit the agent spending allowance before broadcast on SendETH, SendMOR, and OpenSession.
- Restore the hold only when the transaction was never sent.
- DecreaseAllowance and IncreaseAllowance now update the remaining balance inside one Badger transaction, and retry on conflict.

## Base branch

- [x] This PR targets **`dev`** (required for feature/docs/fix PRs)
- [ ] This is a **maintainer promote** into `test` or `main` (skip the line above)

## Test plan

- [x] `go test ./internal/storages/ -count=1` (includes overlapping debit test)
- [x] Compile `internal/system`, `internal/blockchainapi`, `internal/repositories/registries`

## Notes for reviewers

Timeouts after a successful send used to skip the debit, so a later retry could spend past the cap. Holding first, then restoring only on a pre-send failure, keeps the remaining balance honest.